### PR TITLE
import bsddb3 if bsddb fails

### DIFF
--- a/armoryengine.py
+++ b/armoryengine.py
@@ -8910,7 +8910,10 @@ class SettingsFile(object):
 # public domain. 
 #
 
-from bsddb.db import *
+try:
+    from bsddb import db                  # try bsddb
+except ImportError:
+    from bsddb3 import db                 # not found, try release 3 instead
 import json
 import struct
 


### PR DESCRIPTION
Makes ArmoryBitcoin compatible with Mac OS X and Homebrew installation.
Updated installation guide published here: http://pastebin.com/GLQxaAar
