### PR TITLE
Fix for unclickable links in version check dialog

### DIFF
--- a/qtdialogs.py
+++ b/qtdialogs.py
@@ -10444,8 +10444,7 @@ class DlgVersionNotify(ArmoryDialog):
             'reinstall Armory.' % (self.myVersionStr, self.latestVerStr))
 
       lblDescr.setOpenExternalLinks(True)
-      lblDescr.setTextInteractionFlags(Qt.TextSelectableByMouse | \
-                                       Qt.TextSelectableByKeyboard)
+      
       lblChnglog = QRichLabel('')
       if wasRequested:
          lblChnglog = QRichLabel("<b>Changelog</b>:")


### PR DESCRIPTION
Those TextInteractionFlags don't get along with hyperlinks...
And they don't seem to be needed for that label anyway.
