### PR TITLE
compatibility to build in mixed python2/3 environments

### DIFF
--- a/cppForSwig/Makefile
+++ b/cppForSwig/Makefile
@@ -12,7 +12,7 @@ DEPSDIR ?= /usr
 INCLUDE_OPTS += -Icryptopp -DUSE_CRYPTOPP -D__STDC_LIMIT_MACROS 
 LIBRARY_OPTS += -lpthread 
 SWIG_OPTS    += -c++ -python -classic -threads
-PYVER 		 += `python -c 'import sys; print str(sys.version_info[0]) + "." + str(sys.version_info[1])'`
+PYVER 		 += `python2 -c 'import sys; print str(sys.version_info[0]) + "." + str(sys.version_info[1])'`
 
 
 UNAME := $(shell uname)


### PR DESCRIPTION
With this syntax the detection will only work for python2. Is the default python version 3, the build process dies.