### PR TITLE
Convert tuple to list in getUsableTxOutList()

### DIFF
--- a/qtdialogs.py
+++ b/qtdialogs.py
@@ -5383,7 +5383,7 @@ class DlgSendBitcoins(ArmoryDialog):
    #############################################################################
    def getUsableTxOutList(self):
       if self.altBalance==None:
-         return self.wlt.getTxOutList('Spendable')
+         return list(self.wlt.getTxOutList('Spendable'))
       else:
          utxoList = []
          for a160 in self.sourceAddrList:


### PR DESCRIPTION
I get this error when trying to send a transaction:

```
(ERROR) Traceback (most recent call last):
  File "/home/kalakris/bitcoin/BitcoinArmory/qtdialogs.py", line 5133, in createTxAndBroadcast
    txdp = self.validateInputsGetTxDP()
  File "/home/kalakris/bitcoin/BitcoinArmory/qtdialogs.py", line 5312, in validateInputsGetTxDP
    utxoSelect = PySelectCoins(utxoList, totalSend, fee)
  File "/home/kalakris/bitcoin/BitcoinArmory/armoryengine.py", line 5388, in PySelectCoins
    utxos = PySortCoins(unspentTxOutInfo, method)
  File "/home/kalakris/bitcoin/BitcoinArmory/armoryengine.py", line 4980, in PySortCoins
    random.shuffle(utxosNoZC)
  File "/usr/lib/python2.7/random.py", line 288, in shuffle
    x[i], x[j] = x[j], x[i]
TypeError: 'tuple' object does not support item assignment
```

It seems like utxosNoZC should be a list and not a tuple. The attached patch fixes this issue. (May also fix issue #24).
