### PR TITLE
Improvements to paper-wallet restore error handling

### DIFF
--- a/armoryengine.py
+++ b/armoryengine.py
@@ -1095,8 +1095,10 @@ for n,b in zip(NORMALCHARS,EASY16CHARS):
 def binary_to_easyType16(binstr):
    return ''.join([hex_to_base16_map[c] for c in binary_to_hex(binstr)])
 
+# Treat unrecognized characters as 0, to facilitate possibly later recovery of
+# their correct values from the checksum.
 def easyType16_to_binary(b16str):
-   return hex_to_binary(''.join([base16_to_hex_map[c] for c in b16str]))
+   return hex_to_binary(''.join([base16_to_hex_map.get(c, '0') for c in b16str]))
 
 
 def makeSixteenBytesEasy(b16):
@@ -1110,6 +1112,9 @@ def readSixteenEasyBytes(et18):
    b18 = easyType16_to_binary(et18.strip().replace(' ',''))
    b16 = b18[:16]
    chk = b18[ 16:]
+   if chk=='':
+      LOGWARN('Missing checksum when reading EasyType')
+      return (b16, 'No_Checksum')
    b16new = verifyChecksum(b16, chk)
    if len(b16new)==0:
       return ('','Error_2+')

--- a/extras/unfrag_wallet.py
+++ b/extras/unfrag_wallet.py
@@ -108,6 +108,8 @@ for i,fragMap in enumerate(frags):
          exit(0)
       elif err=='Fixed_1':
          print ' Error corrected,  %s:%s' % (files[i], prefix)
+      elif err=='No_Checksum':
+         print ' Checksum absent,  %s:%s' % (files[i], prefix)
       return bin16
 
    x,y = ['']*4, ['']*4

--- a/qtdialogs.py
+++ b/qtdialogs.py
@@ -3752,41 +3752,44 @@ class DlgImportPaperWallet(ArmoryDialog):
          self.lineEdits[i].setText(' '.join(quads))
          
    
-
    def verifyUserInput(self):
-      nError = 0
+      def englishNumberList(nums):
+         nums = map(str, nums)
+         if len(nums)==1:
+            return nums[0]
+         return ', '.join(nums[:-1]) + ' and ' + nums[-1]
+
+      errorLines = []
       for i in range(4):
          hasError=False
          try:
-            rawBin = easyType16_to_binary( str(self.lineEdits[i].text()).replace(' ','') )
-            data, chk = rawBin[:16], rawBin[16:]
-            fixedData = verifyChecksum(data, chk)
-            if len(fixedData)==0:
-               hasError=True
-         except KeyError:
-            hasError=True
+            data, err = readSixteenEasyBytes(str(self.lineEdits[i].text()))
+         except (KeyError, TypeError):
+            data, err = ('', 'Exception')
             
-         if hasError:
+         if data=='':
             reply = QMessageBox.critical(self, 'Verify Wallet ID', \
-               'There is an error in the data you entered that could not be '
-               'fixed automatically.  Please double-check that you entered the '
-               'text exactly as it appears on the wallet-backup page.', \
+               'There is an error on line ' + str(i+1) + ' of the data you '
+               'entered, which could not be fixed automatically.  Please '
+               'double-check that you entered the text exactly as it appears '
+               'on the wallet-backup page.', \
                QMessageBox.Ok)
             LOGERROR('Error in wallet restore field')
             self.labels[i].setText('<font color="red">'+str(self.labels[i].text())+'</font>')
             return
-         if not fixedData==data:
-            data = fixedData
-            nError+=1
+         if err=='Fixed_1' or err=='No_Checksum':
+            errorLines += [i+1]
 
          self.wltDataLines[i] = data
 
-      if nError>0:
-         pluralStr = 'error' if nError==1 else 'errors'
+      if errorLines:
+         pluralChar = '' if len(errorLines)==1 else 's'
+         article = ' an' if len(errorLines)==1 else ''
          QMessageBox.question(self, 'Errors Corrected!', \
-            'Detected ' + str(nError) + ' ' + pluralStr + ' '
-            'in the data you entered.  Armory attempted to fix the ' + 
-            pluralStr + ' but it is not always right.  Be sure '
+            'Detected' + article +' error' + pluralChar + ' on line' +
+            pluralChar + ' ' + englishNumberList(errorLines) +
+            ' in the data you entered.  Armory attempted to fix the ' + 
+            'error' + pluralChar + ' but it is not always right.  Be sure '
             'to verify the "Wallet Unique ID" closely on the next window.', \
             QMessageBox.Ok)
             


### PR DESCRIPTION
Various improvements to error handling when restoring wallets from paper
backups. Handle out-of-charset characters (treated as zeroes), odd-length
inputs (treated as uncorrectable errors), missing checksums (treated as
corrected errors, instead of being silently ignored).

Also print line numbers when reporting errors during restore.
