### PR TITLE
Raspberry Pi compile compatibility

### DIFF
--- a/armoryengine.py
+++ b/armoryengine.py
@@ -773,6 +773,7 @@ def GetSystemDetails():
 
       # Get CPU name
       cpuinfo = subprocess_check_output(['cat','/proc/cpuinfo'])
+      out.CpuStr = "Unknown"
       for line in cpuinfo.split('\n'):
          if line.strip().lower().startswith('model name'):
             out.CpuStr = line.split(':')[1].strip()

--- a/cppForSwig/Makefile
+++ b/cppForSwig/Makefile
@@ -1,6 +1,7 @@
 COMPILER = g++ 
 #COMPILER_OPTS = -c -g -Wall -fPIC -D_DEBUG
 COMPILER_OPTS = -c -O2 -pipe -fPIC 
+EGREP = egrep
 
 #**************************************************************************
 LINKER = g++ 
@@ -12,7 +13,15 @@ DEPSDIR ?= /usr
 INCLUDE_OPTS += -Icryptopp -DUSE_CRYPTOPP -D__STDC_LIMIT_MACROS 
 LIBRARY_OPTS += -lpthread 
 SWIG_OPTS    += -c++ -python -classic -threads
-PYVER 		 += `python2 -c 'import sys; print str(sys.version_info[0]) + "." + str(sys.version_info[1])'`
+
+PYVER_IS_VER2 = $(shell python -c 'import sys; print str(sys.version_info[0]) + "." + str(sys.version_info[1])' | $(EGREP) -c "^2\.")
+
+ifneq ($(PYVER_IS_VER2),0)  # use python instead of python2, if python returns a version of 2.x
+  PYVER            += `python -c 'import sys; print str(sys.version_info[0]) + "." + str(sys.version_info[1])'`
+else
+  PYVER            += `python2 -c 'import sys; print str(sys.version_info[0]) + "." + str(sys.version_info[1])'`
+endif
+
 
 
 UNAME := $(shell uname)

--- a/cppForSwig/cryptopp/Makefile
+++ b/cppForSwig/cryptopp/Makefile
@@ -12,6 +12,7 @@ MKDIR = mkdir
 EGREP = egrep
 UNAME = $(shell uname)
 ISX86 = $(shell uname -m | $(EGREP) -c "i.86|x86|i86|amd64")
+IS_SUN_CC = $(shell $(CXX) -V 2>&1 | $(EGREP) -c "CC: Sun")
 
 # Default prefix for make install
 ifeq ($(PREFIX),)
@@ -27,7 +28,6 @@ ifeq ($(ISX86),1)
 GCC42_OR_LATER = $(shell $(CXX) -v 2>&1 | $(EGREP) -c "^gcc version (4.[2-9]|[5-9])")
 INTEL_COMPILER = $(shell $(CXX) --version 2>&1 | $(EGREP) -c "\(ICC\)")
 ICC111_OR_LATER = $(shell $(CXX) --version 2>&1 | $(EGREP) -c "\(ICC\) ([2-9][0-9]|1[2-9]|11\.[1-9])")
-IS_SUN_CC = $(shell $(CXX) -V 2>&1 | $(EGREP) -c "CC: Sun")
 GAS210_OR_LATER = $(shell echo "" | $(AS) -v 2>&1 | $(EGREP) -c "GNU assembler version (2\.[1-9][0-9]|[3-9])")
 GAS217_OR_LATER = $(shell echo "" | $(AS) -v 2>&1 | $(EGREP) -c "GNU assembler version (2\.1[7-9]|2\.[2-9]|[3-9])")
 GAS219_OR_LATER = $(shell echo "" | $(AS) -v 2>&1 | $(EGREP) -c "GNU assembler version (2\.19|2\.[2-9]|[3-9])")


### PR DESCRIPTION
This fixes 3 problems that prevent the latest repo from being compiled on a Raspberry Pi.

The cryptopp Makefile only does the Sun architecture check for x86 processors.  However, blank is considered Sun architecture.  This moves the check outside the if, so the check is always performed.  This mean Sun specific flags are not added.

The Raspbian Wheezy version of linux doesn't have a python2 link in /usr/bin.  The python link calls python 2.x.   The Makefile is updated to use python if the python link calls version 2.x.  Otherwise, it uses python2.

Finally, there is an exception when starting the GUI from armoryengine.py.  /proc/cpuinfo is scanned for "model name".  However, the Raspberry doesn't have that line.  This means that the CpuStr field is left as null.

These changes allow make all to build the source files for use on the Pi.
