### PR TITLE
Armory OS X script should pass command line arguments

### DIFF
--- a/osxbuild/Armory
+++ b/osxbuild/Armory
@@ -2,4 +2,4 @@
 cd "${0%/*}"
 
 export DYLD_LIBRARY_PATH=../Dependencies/QtCore.framework/Versions/Current:../Dependencies/QtGui.framework/Versions/Current:../Dependencies:$DYLD_LIBRARY_PATH
-bin/python armorybuild/ArmoryQt.pyc
+bin/python armorybuild/ArmoryQt.pyc $*


### PR DESCRIPTION
This helps passing arguments such as --testnet
