### PR TITLE
Add OS X Memory and CpuStr values.

### DIFF
--- a/armoryengine.py
+++ b/armoryengine.py
@@ -802,7 +802,10 @@ def GetSystemDetails():
       out.Memory = stat.ullTotalPhys/1024.
       out.CpuStr = platform.processor()
    else:
-      raise OSError, "Can't get system specs in OSX"
+      memsizeStr = subprocess_check_output('sysctl hw.memsize', shell=True)
+      out.Memory = int(memsizeStr.split(": ")[1]) / 1024
+      out.CpuStr = subprocess_check_output(
+          'sysctl -n machdep.cpu.brand_string', shell=True)
 
    out.NumCores = multiprocessing.cpu_count()
    out.IsX64 = platform.architecture()[0].startswith('64')


### PR DESCRIPTION
I found out how to get the amount of RAM and the CPU name from the command-line on OS X (10.9 Mavericks anyway). Hopefully, it hasn't changed from before.

For the CPU name, I get a string like "Intel(R) Core(TM) i5-2410M CPU @ 2.30GHz". For the amount of memory, I get 4294967296, which I divided by 1024 to get 4194304.

I'm fairly new to Armory, so I didn't find where those values would show up in the GUI.

Thanks,
