### PR TITLE
Change SWIG_INC & STATICPYTHON for Homebrew OS X

### DIFF
--- a/cppForSwig/Makefile
+++ b/cppForSwig/Makefile
@@ -26,8 +26,8 @@ ifeq ($(UNAME), Darwin)
    # Red Emerald in this thread: 
    #    https://bitcointalk.org/index.php?topic=73648.msg976015#msg976015
 	# The makefile updates he shows are already tied into this if/else branch
-   SWIG_INC     += -I"/usr/include/python$(PYVER)"
-   STATICPYTHON +=   "/usr/lib/python$(PYVER)/config/libpython$(PYVER).a"
+   SWIG_INC      += `python-config --includes`
+   STATICPYTHON  += -F `brew --prefix`/opt/python/Frameworks -framework Python
 else
    SWIG_INC     += -I"$(DEPSDIR)/include/python$(PYVER)"
 	# Comment this .a file for 13.04


### PR DESCRIPTION
I got Armory to compile using this patch. Now, I can just run it using ``python ArmoryQt.py`` instead of the using the system Python way the gist linked on the Armory website.