### PR TITLE
Allow parallel build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,10 @@
 # I am just calling them, here.
 
 all :
-	cd cppForSwig; make swig
+	$(MAKE) -C cppForSwig swig
 
 clean :
-	cd cppForSwig; make clean
+	$(MAKE) -C cppForSwig clean
 	rm -rf osxbuild/Armory.app
 	rm -rf osxbuild/env
 


### PR DESCRIPTION
This allows one to build in parallel with make -j8 (and fixes the "no job server found" error).
I also believe the two rm in the clean rule were not effective since you did a cd in cppForSwig.

Btw I think you should switch to a more robust build system like cmake.
