### PR TITLE
Block BDM during scanRegisteredTxForWallet.

### DIFF
--- a/armoryengine/BDM.py
+++ b/armoryengine/BDM.py
@@ -177,6 +177,7 @@ class BlockDataManagerThread(threading.Thread):
 
       # Flags
       self.startBDM      = False
+      self.alwaysBlock   = False
       self.doShutdown    = False
       self.aboutToRescan = False
       self.errorOut      = 0
@@ -297,6 +298,8 @@ class BlockDataManagerThread(threading.Thread):
       So setting wait=True is NOT identical to setBlocking(True), since using
       wait=True with blocking=False will break when the timeout has been reached
       """
+      prevBlocking = self.alwaysBlock
+
       if doblock:
          self.alwaysBlock = True
          self.mtWaitSec   = None
@@ -304,6 +307,7 @@ class BlockDataManagerThread(threading.Thread):
          self.alwaysBlock = False
          self.mtWaitSec   = newTimeout
 
+      return prevBlocking
 
    #############################################################################
    def Reset(self, wait=None):
@@ -808,6 +812,7 @@ class BlockDataManagerThread(threading.Thread):
       This method can be called from a non BDM class, but should only do so if 
       that class method was called by the BDM (thus, no conflicts)
       """
+      LOGDEBUG('scanRegisteredTxForWallet_bdm_direct')
       self.bdm.scanRegisteredTxForWallet(cppWlt, startBlk, endBlk)
 
    #############################################################################
@@ -989,8 +994,10 @@ class BlockDataManagerThread(threading.Thread):
 
       # missingBlocks = self.bdm.missingBlockHashes()
       
+      prevBlocking = self.bdm.setBlocking(True)
       self.bdm.scanBlockchainForTx(self.masterCppWallet)
       self.bdm.saveScrAddrHistories()
+      self.bdm.setBlocking(prevBlocking)
 
 
    #############################################################################

--- a/armoryengine/PyBtcWallet.py
+++ b/armoryengine/PyBtcWallet.py
@@ -312,10 +312,14 @@ class PyBtcWallet(object):
          # BDM-thread queue, must call its methods directly
          
          if self.calledFromBDM:
+            LOGDEBUG('scanRegisteredTxForWallet_bdm_direct calledFromBDM, so not blocking.')
             TheBDM.scanRegisteredTxForWallet_bdm_direct(self.cppWallet, startBlk)
             self.lastSyncBlockNum = TheBDM.getTopBlockHeight_bdm_direct()
          else:
-            TheBDM.scanRegisteredTxForWallet(self.cppWallet, startBlk, wait=True)
+            LOGDEBUG('scanRegisteredTxForWallet not calledFromBDM, so blocking.')
+            prevBlocking = TheBDM.setBlocking(True)
+            TheBDM.scanRegisteredTxForWallet(self.cppWallet, startBlk)
+            TheBDM.setBlocking(prevBlocking)
             self.lastSyncBlockNum = TheBDM.getTopBlockHeight(wait=True)
             
             wltLE = self.cppWallet.getTxLedger()


### PR DESCRIPTION
This bugfix resolves a reproducible coredump resulting from BDM timeouts, while scanning a wallet's transactions.  

Since scanRegisteredTxForWallet can take a long time, block the BDM, which would timeout.

While setting and clearing blocking mode, announce the previous mode, to restore it.

Also, do not call through to the cpp layer using the wrong argument types!  wait=True gets dynamically munged into a valid argument, even though it's not.  (The correct third argument is endBlk, and it defaults appropriately.)
