### PR TITLE
README: Added Python psutil to the list of dependencies.

### DIFF
--- a/README
+++ b/README
@@ -82,6 +82,11 @@
             Linux:   Install package 'python-twisted'
             Windows: "http://twistedmatrix.com/trac/wiki/Downloads"
 
+   - Python psutil -- process information utility
+            Linux:   Install package 'python2-psutil' or 'python-psutil',
+                     whichever one supports Python 2.6/2.7 on your distro.
+            Windows: https://code.google.com/p/psutil/
+
    - PyQt 4 (for Python 2.X)
             Linux:   Install  "libqtcore4", "libqt4-dev" and "python-qt4"
             Windows: "http://www.riverbankcomputing.co.uk/software/pyqt/download"


### PR DESCRIPTION
Hello, Alan.

To help out other users, I thought it would be nice to add information about psutil to the README so they don't have to go track it down on their own like I did.  This pull request adds that information.

I have gotten Armory working on my Raspberry Pi, and I had to install "python-psutil" there.  On Arch Linux, I needed to install "python2-psutil" because they consider "python" to always mean the latest version of Python, and any package related to an older version must have the version number in its name.
