### PR TITLE
Only look for mimeTypes.rdf in the Firefox profile directory

### DIFF
--- a/ArmoryQt.py
+++ b/ArmoryQt.py
@@ -1294,7 +1294,7 @@ class ArmoryMainWindow(QMainWindow):
       rdfexternalApp = 'about=\"urn:scheme:externalApplication:bitcoin\"'
 
       #find mimeTypes.rdf file
-      home = os.getenv('HOME')
+      home = os.path.join(os.getenv('HOME'), '.mozilla', 'firefox')
       out,err = execAndWait('find %s -type f -name \"mimeTypes.rdf\"' % home)
 
       for rdfs in out.split('\n'):


### PR DESCRIPTION
Scanning the entire home directory for this consumes a ton of resources, is pointless and keeps screwing with my Firefox source directories. Restrict the search to $HOME/.mozilla/firefox.