### PR TITLE
Fix slow and potentially-error-prone scan for mimeTypes.rdf

### DIFF
--- a/ArmoryQt.py
+++ b/ArmoryQt.py
@@ -28,6 +28,7 @@ import threading
 import time
 import traceback
 import webbrowser
+import glob
 
 
 from PyQt4.QtCore import *
@@ -1450,14 +1451,20 @@ class ArmoryMainWindow(QMainWindow):
       rdfexternalApp = 'about=\"urn:scheme:externalApplication:bitcoin\"'
 
       #find mimeTypes.rdf file
-      home = os.getenv('HOME')
-      out,err = execAndWait('find %s -type f -name \"mimeTypes.rdf\"' % home)
-
-      for rdfs in out.split('\n'):
+      rdfs_found = glob.glob(
+          os.path.join(
+              os.path.expanduser("~"),
+              ".mozilla",
+              "firefox",
+              "*",
+              "mimeTypes.rdf"
+          )
+      )
+      for rdfs in rdfs_found:
          if rdfs:
             try:
                FFrdf = open(rdfs, 'r+')
-            except:
+            except IOError:
                continue
 
             ct = FFrdf.readlines()

--- a/Makefile
+++ b/Makefile
@@ -52,9 +52,9 @@ install : all
 	cp BitTornado/*.py $(DESTDIR)$(PREFIX)/lib/armory/BitTornado
 	cp BitTornado/BT1/*.py $(DESTDIR)$(PREFIX)/lib/armory/BitTornado/BT1
 	cp default_bootstrap.torrent $(DESTDIR)$(PREFIX)/lib/armory
-	sed "s:python /usr:python $(PREFIX):g" < dpkgfiles/armory.desktop > $(DESTDIR)$(PREFIX)/share/applications/armory.desktop
-	sed "s:python /usr:python $(PREFIX):g" < dpkgfiles/armoryoffline.desktop > $(DESTDIR)$(PREFIX)/share/applications/armoryoffline.desktop
-	sed "s:python /usr:python $(PREFIX):g" < dpkgfiles/armorytestnet.desktop > $(DESTDIR)$(PREFIX)/share/applications/armorytestnet.desktop
+	sed "s:python /usr:python $(PREFIX):g" < dpkgfiles/armory.desktop | sed "s:Exec=/usr:Exec=$(PREFIX):g" > $(DESTDIR)$(PREFIX)/share/applications/armory.desktop
+	sed "s:python /usr:python $(PREFIX):g" < dpkgfiles/armoryoffline.desktop | sed "s:Exec=/usr:Exec=$(PREFIX):g" > $(DESTDIR)$(PREFIX)/share/applications/armoryoffline.desktop
+	sed "s:python /usr:python $(PREFIX):g" < dpkgfiles/armorytestnet.desktop | sed "s:Exec=/usr:Exec=$(PREFIX):g" > $(DESTDIR)$(PREFIX)/share/applications/armorytestnet.desktop
 	#$(MAKE) -C po install DESTDIR=$(DESTDIR) PREFIX=$(PREFIX)
 
 all-test-tools: all

--- a/dpkgfiles/armory
+++ b/dpkgfiles/armory
@@ -1,2 +1,5 @@
-#!/bin/sh
-exec python /usr/lib/armory/ArmoryQt.py "$@"
+#!/bin/bash
+
+unset CDPATH
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+exec python "$DIR"/../lib/armory/ArmoryQt.py "$@"


### PR DESCRIPTION
The scan can take literally hours on a huge home directory, and it can snag many false positives.  Limit scan to well-known directories.