### PR TITLE
Reduce HDD IO significantly by respecting "DNAA_DefaultApp" setting.

### DIFF
--- a/ArmoryQt.py
+++ b/ArmoryQt.py
@@ -214,7 +214,8 @@ class ArmoryMainWindow(QMainWindow):
 
       # Setup system tray and register "bitcoin:" URLs with the OS
       self.setupSystemTray()
-      self.setupUriRegistration()
+      if self.getSettingOrSetDefault("DNAA_DefaultApp", False):
+         self.setupUriRegistration()
 
 
       self.extraHeartbeatSpecial  = []


### PR DESCRIPTION
If self.setupUriRegistration is called, "find $HOME -name mimeTypes.rdf" is executed, and the command consumes a lot of hard disk IO, which I don't like.

self.setupUriRegistration should be invoked
only if DNAA_DefaultApp is true.