### PR TITLE
Updated to clearify def URL handler statements

### DIFF
--- a/ArmoryQt.py
+++ b/ArmoryQt.py
@@ -1394,7 +1394,7 @@ class ArmoryMainWindow(QMainWindow):
             # Don't bother the user on the first load with it if verification is
             # needed.  They have enough to worry about with this weird new program...
             if not self.getSettingOrSetDefault('DNAA_DefaultApp', False):
-               reply = MsgBoxWithDNAA(MSGBOX.Question, 'Default URL Handler', \
+               reply = MsgBoxWithDNAA(MSGBOX.Question, 'Default Bitcoin URL Handler', \
                   'Armory is not set as your default application for handling '
                   '"bitcoin:" links.  Would you like to use Armory as the '
                   'default?', 'Do not ask this question again')
@@ -1465,7 +1465,7 @@ class ArmoryMainWindow(QMainWindow):
             # If another application has it, ask for permission to change it
             # Don't bother the user on the first load with it if verification is
             # needed.  They have enough to worry about with this weird new program...
-            reply = MsgBoxWithDNAA(MSGBOX.Question, 'Default URL Handler', \
+            reply = MsgBoxWithDNAA(MSGBOX.Question, 'Default Bitcoin URL Handler', \
                'Armory is not set as your default application for handling '
                '"bitcoin:" links.  Would you like to use Armory as the '
                'default?', 'Do not ask this question again')

--- a/qtdialogs.py
+++ b/qtdialogs.py
@@ -9011,7 +9011,7 @@ class DlgSettings(ArmoryDialog):
 
 
       lblDefaultUriTitle = QRichLabel(tr("""
-         <b>Set Armory as default URL handler</b>"""))
+         <b>Set Armory as default Bitcoin URL handler</b>"""))
       lblDefaultURI = QRichLabel(tr("""
          Set Armory to be the default when you click on "bitcoin:"
          links in your browser or in emails.


### PR DESCRIPTION
Without specifying the type of URL handler, i.e. (Bitcoin URL), the user gets the impression that Armory is requesting to handle any urls including canonical ones like http. Although the description following it does specify the type of url, the size and font weight of the header can obfuscate it and thus contribute to unnecessary friction.
