### PR TITLE
Armoryd: Fix P2SH script output script for change.

### DIFF
--- a/armoryd.py
+++ b/armoryd.py
@@ -1962,7 +1962,7 @@ class Armory_Json_Rpc_Server(jsonrpc.JSONRPC):
                                              self.convLBDictToList())
             outputPairs.append( [ustxScr['Script'], totalChange] )
          else:
-            outputPairs.append( [lbox.binScript, totalChange] )
+            outputPairs.append( [script_to_p2sh_script(lbox.binScript), totalChange] )
       random.shuffle(outputPairs)
 
       # If this has nothing to do with lockboxes, we need to make sure


### PR DESCRIPTION
See https://bitcointalk.org/index.php?topic=919202.msg10309713#msg10309713
for discussion.

Armoryd would output an old-style P2PK multisig script, rather than
the new P2SH style.