### PR TITLE
Autotools: Use correct scripts when making Armory.app in Makefile.am

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -75,8 +75,8 @@ Armory-tmp: all osxbuild/install-py3 osxbuild/install-qt5
 	$(MAKE) DESTDIR=osxbuild/Armory-tmp/Contents/MacOS/py PREFIX=/usr install
 	cp osxbuild/Info.plist osxbuild/Armory-tmp/Contents
 	cp img/armory_icon_fullres.icns osxbuild/Armory-tmp/Contents/Resources/Icon.icns
-	cp osxbuild/Armory-script-autotools.sh osxbuild/Armory-tmp/Contents/MacOS/Armory
-	cp osxbuild/armoryd-script-autotools.sh osxbuild/Armory-tmp/Contents/MacOS/armoryd
+	cp osxbuild/Armory-script.sh osxbuild/Armory-tmp/Contents/MacOS/Armory
+	cp osxbuild/armoryd-script.sh osxbuild/Armory-tmp/Contents/MacOS/armoryd
 	cp -r osxbuild/install-py3/Python.framework osxbuild/Armory-tmp/Contents/Frameworks/
 	cp -r osxbuild/install-qt5/lib/Qt{Core,Gui,Network}.framework osxbuild/Armory-tmp/Contents/Frameworks/
 	chmod +x osxbuild/Armory-tmp/Contents/MacOS/Armory


### PR DESCRIPTION
@droark - I forgot to change the path to the scripts in the Makefile when I removed the autotools versions of the scripts that I made. So I am making this PR to fix the path to the OS X scripts.

Let me know if you would rather have me make a single big PR again. I figured that this should be merged in now because it fixes an issue with the previous PR.