### PR TITLE
Autotools: Add deb build support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,7 +5,6 @@ all:
 	$(MAKE) -C cppForSwig
 
 clean-local:
-	$(MAKE) -C cppForSwig clean
 	rm -f CppBlockUtils.py
 	rm -f qrc_img_resources.py
 	rm -f _CppBlockUtils.so
@@ -46,6 +45,13 @@ install-exec-local:
 	cp BitTornado/*.py $(DESTDIR)$(PREFIX)/lib/armory/BitTornado
 	cp BitTornado/BT1/*.py $(DESTDIR)$(PREFIX)/lib/armory/BitTornado/BT1
 	cp default_bootstrap.torrent $(DESTDIR)$(PREFIX)/lib/armory
+
+if TARGET_LINUX
+if BUILD_LINUX
+deb:
+	python dpkgfiles/make_deb_package.py
+endif
+endif
 
 if TARGET_DARWIN
 if BUILD_LINUX

--- a/dpkgfiles/control32
+++ b/dpkgfiles/control32
@@ -2,7 +2,7 @@ Source: armory
 Section: net
 Priority: extra
 Maintainer: Armory Technologies, Inc. <support@bitcoinarmory.com>
-Build-Depends: python (>= 2.6), debhelper (>= 7), pyqt4-dev-tools, swig, libqtcore4, libqt4-dev, python-qt4, python-dev, python-twisted, python-psutil
+Build-Depends: python (>= 2.6), debhelper (>= 7), dh-autoreconf (>= 7), pyqt4-dev-tools, swig, libqtcore4, libqt4-dev, python-qt4, python-dev, python-twisted, python-psutil, rsync
 Standards-Version: 3.8.3
 Homepage: http://www.bitcoinarmory.com
 

--- a/dpkgfiles/control64
+++ b/dpkgfiles/control64
@@ -2,7 +2,7 @@ Source: armory
 Section: net
 Priority: extra
 Maintainer: Armory Technologies, Inc. <support@bitcoinarmory.com>
-Build-Depends: python (>= 2.6), debhelper (>= 7), pyqt4-dev-tools, swig, libqtcore4, libqt4-dev, python-qt4, python-dev, python-twisted, python-psutil
+Build-Depends: python (>= 2.6), debhelper (>= 7), dh-autoreconf (>= 7), pyqt4-dev-tools, swig, libqtcore4, libqt4-dev, python-qt4, python-dev, python-twisted, python-psutil, rsync
 Standards-Version: 3.8.3
 Homepage: http://www.bitcoinarmory.com
 

--- a/dpkgfiles/make_deb_package.README
+++ b/dpkgfiles/make_deb_package.README
@@ -1,0 +1,36 @@
+Instructions for using make_deb_package.py outside of Gitian
+
+
+Note that you probably don't want to follow these instructions. Instead, you
+probably want to just run the Gitian build script to generate the deb.
+
+1) We use cowbuilder to build in a chroot, so you need to prepare a chroot with
+   cowbuilder first (instructions from the Debian reproducible build project):
+
+      sudo cowbuilder --create --distribution codename --basepath /var/cache/pbuilder/base-reproducible.cow
+      sudo cowbuilder --login --save-after-exec --basepath /var/cache/pbuilder/base-reproducible.cow
+      echo 'deb http://reproducible.alioth.debian.org/debian/ ./' > /etc/apt/sources.list.d/reproducible.list
+      apt-get install busybox
+      busybox wget -O- http://reproducible.alioth.debian.org/reproducible.gpg | apt-key add -
+      apt-get purge busybox
+      apt-key fingerprint | grep '49B6 5747 36D0 B637 CC37  01EA 5DB7 CA67 EA59 A31F' || { echo 'Something is wrong' && exit 1; }
+      apt-get update
+      apt-get upgrade
+      exit 0
+
+   The above instructions install the Debian reproducible build toolchain in
+   the chroot. You replace codename with the actual codename of the
+   distribution you are using (sid, jessie, wheezy, trusty, precise). You can
+   also change the name of the chroot from base-reproducible to whatever you
+   like.
+
+2) Make sure you have libfaketime installed on the machine you are running the
+   make_deb_package.py script from (not the chroot).
+
+3) Run "python dpkgfiles/make_deb_package.py base-reproducible.cow" from the
+   Armory root directory. Alternatively, run "make deb" after having run
+   "./configure".
+
+4) You should find the results of the build in ../armory-build/.
+
+Note: These instructions have been tested on a Debian Jessie host.

--- a/dpkgfiles/rules
+++ b/dpkgfiles/rules
@@ -10,7 +10,7 @@
 #export DH_VERBOSE=1
 
 %:
-	dh $@
+	dh $@ --with autoreconf
 
 override_dh_auto_build:
 	make PYVER=python2.7


### PR DESCRIPTION
@droark - These are the changes I emailed you about to get a reproducible deb build working in preparation for the use of the script with Gitian.

As is, the resulting deb is consistent across rebuilds for me. I only tested the script on Debian Jessie so far. I imagine we will need to pick a single version of a single distro to build against to get a consistent result. I would say that the oldest version of Ubuntu we want to support (say 12.04) is a good idea, but we need a new enough libstdc++, so we probably need 14.04.

In fact, since the deb is already reproducible, we don't even need to use Gitian for the deb builds. But we might want to use Gitian so as to have a consistent setup for signing and verifying the builds.

If we did just want to use the script as it is now, we can just sign the buildinfo file produced by the build. It contains checksums for the files produced, so people can verify the hashes of the files in the buildinfo file and the signature on the buildinfo file itself. Since the source package itself is not reproducible, we can strip that hash from the buildinfo file before signing so as not to confuse people.

This script now uses a chroot in which to build the package. I just didn't want to install the Debian reproducible toolchain on my main system, so I used the chroot. The last line of the script can be changed back to use dpkg-buildpackage for the Gitian VM. In fact it is probably a good idea to add an optional argument, so that dpkg-buildpackage is used when building in a Gitian VM, but the chroot is used otherwise.

Let me know what you think, particularly about using the script as it is now vs using Gitian with the script.