### PR TITLE
Debian Package Static Linking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ osxbuild/install-qt5/
 /armory_*_raspbian-armhf*
 
 /dpkgfiles/control
+/dpkgfiles/rules
 
 # autoreconf
 Makefile.in

--- a/Makefile.am
+++ b/Makefile.am
@@ -48,8 +48,15 @@ install-exec-local:
 
 if TARGET_LINUX
 if BUILD_LINUX
-deb:
-	python dpkgfiles/make_deb_package.py
+deb: all
+	@while [ -z "$$AMD64_CHROOT" ]; do \
+		read -r -p "Name of amd64 chroot: " AMD64_CHROOT; \
+	done && \
+	while [ -z "$$I386_CHROOT" ]; do \
+		read -r -p "Name of i386 chroot: " I386_CHROOT; \
+	done && \
+	python dpkgfiles/make_deb_package.py $$AMD64_CHROOT 64 1 0 && \
+	python dpkgfiles/make_deb_package.py $$I386_CHROOT 32 1 0
 endif
 endif
 

--- a/build-aux/m4/ax_pkg_swig.m4
+++ b/build-aux/m4/ax_pkg_swig.m4
@@ -1,0 +1,135 @@
+# ===========================================================================
+#        http://www.gnu.org/software/autoconf-archive/ax_pkg_swig.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_PKG_SWIG([major.minor.micro], [action-if-found], [action-if-not-found])
+#
+# DESCRIPTION
+#
+#   This macro searches for a SWIG installation on your system. If found,
+#   then SWIG is AC_SUBST'd; if not found, then $SWIG is empty.  If SWIG is
+#   found, then SWIG_LIB is set to the SWIG library path, and AC_SUBST'd.
+#
+#   You can use the optional first argument to check if the version of the
+#   available SWIG is greater than or equal to the value of the argument. It
+#   should have the format: N[.N[.N]] (N is a number between 0 and 999. Only
+#   the first N is mandatory.) If the version argument is given (e.g.
+#   1.3.17), AX_PKG_SWIG checks that the swig package is this version number
+#   or higher.
+#
+#   As usual, action-if-found is executed if SWIG is found, otherwise
+#   action-if-not-found is executed.
+#
+#   In configure.in, use as:
+#
+#     AX_PKG_SWIG(1.3.17, [], [ AC_MSG_ERROR([SWIG is required to build..]) ])
+#     AX_SWIG_ENABLE_CXX
+#     AX_SWIG_MULTI_MODULE_SUPPORT
+#     AX_SWIG_PYTHON
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Sebastian Huber <sebastian-huber@web.de>
+#   Copyright (c) 2008 Alan W. Irwin
+#   Copyright (c) 2008 Rafael Laboissiere <rafael@laboissiere.net>
+#   Copyright (c) 2008 Andrew Collier
+#   Copyright (c) 2011 Murray Cumming <murrayc@openismus.com>
+#
+#   This program is free software; you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation; either version 2 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+
+#serial 11
+
+AC_DEFUN([AX_PKG_SWIG],[
+        # Ubuntu has swig 2.0 as /usr/bin/swig2.0
+        AC_PATH_PROGS([SWIG],[swig swig2.0])
+        if test -z "$SWIG" ; then
+                m4_ifval([$3],[$3],[:])
+        elif test -n "$1" ; then
+                AC_MSG_CHECKING([SWIG version])
+                [swig_version=`$SWIG -version 2>&1 | grep 'SWIG Version' | sed 's/.*\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\).*/\1/g'`]
+                AC_MSG_RESULT([$swig_version])
+                if test -n "$swig_version" ; then
+                        # Calculate the required version number components
+                        [required=$1]
+                        [required_major=`echo $required | sed 's/[^0-9].*//'`]
+                        if test -z "$required_major" ; then
+                                [required_major=0]
+                        fi
+                        [required=`echo $required | sed 's/[0-9]*[^0-9]//'`]
+                        [required_minor=`echo $required | sed 's/[^0-9].*//'`]
+                        if test -z "$required_minor" ; then
+                                [required_minor=0]
+                        fi
+                        [required=`echo $required | sed 's/[0-9]*[^0-9]//'`]
+                        [required_patch=`echo $required | sed 's/[^0-9].*//'`]
+                        if test -z "$required_patch" ; then
+                                [required_patch=0]
+                        fi
+                        # Calculate the available version number components
+                        [available=$swig_version]
+                        [available_major=`echo $available | sed 's/[^0-9].*//'`]
+                        if test -z "$available_major" ; then
+                                [available_major=0]
+                        fi
+                        [available=`echo $available | sed 's/[0-9]*[^0-9]//'`]
+                        [available_minor=`echo $available | sed 's/[^0-9].*//'`]
+                        if test -z "$available_minor" ; then
+                                [available_minor=0]
+                        fi
+                        [available=`echo $available | sed 's/[0-9]*[^0-9]//'`]
+                        [available_patch=`echo $available | sed 's/[^0-9].*//'`]
+                        if test -z "$available_patch" ; then
+                                [available_patch=0]
+                        fi
+                        # Convert the version tuple into a single number for easier comparison.
+                        # Using base 100 should be safe since SWIG internally uses BCD values
+                        # to encode its version number.
+                        required_swig_vernum=`expr $required_major \* 10000 \
+                            \+ $required_minor \* 100 \+ $required_patch`
+                        available_swig_vernum=`expr $available_major \* 10000 \
+                            \+ $available_minor \* 100 \+ $available_patch`
+
+                        if test $available_swig_vernum -lt $required_swig_vernum; then
+                                AC_MSG_WARN([SWIG version >= $1 is required.  You have $swig_version.])
+                                SWIG=''
+                                m4_ifval([$3],[$3],[])
+                        else
+                                AC_MSG_CHECKING([for SWIG library])
+                                SWIG_LIB=`$SWIG -swiglib`
+                                AC_MSG_RESULT([$SWIG_LIB])
+                                m4_ifval([$2],[$2],[])
+                        fi
+                else
+                        AC_MSG_WARN([cannot determine SWIG version])
+                        SWIG=''
+                        m4_ifval([$3],[$3],[])
+                fi
+        fi
+        AC_SUBST([SWIG_LIB])
+])

--- a/build-aux/m4/ax_sip_devel.m4
+++ b/build-aux/m4/ax_sip_devel.m4
@@ -94,8 +94,10 @@ fi
 
 # check for sip.h
 dnl this part of the code to detect python version and include path
-dnl  was taken from AX_PYTHON_DEVEL macro, (rev. 2008-04-12)
-python_path=`echo $PYTHON | sed "s,/bin.*$,,"`
+dnl  was taken from AX_PYTHON_DEVEL macro, (rev. 2013)
+dnl  modified by ATI
+python_path=`$PYTHON -c "import distutils.sysconfig; \
+        print (disutils.sysconfig.get_python_inc ());"`
 for i in "$python_path/include/python$PYTHON_VERSION/" "$python_path/include/python/" "$python_path/" ; do
         python_path=`find $i -type f -name Python.h -print | sed "1q"`
         if test -n "$python_path" ; then

--- a/configure.ac
+++ b/configure.ac
@@ -18,6 +18,8 @@ case $host in
         ;;
     *darwin*)
         TARGET_OS=darwin
+        dnl Check for sip executable and sip include path
+        AX_SIP_DEVEL
         ;;
     *linux*)
         TARGET_OS=linux
@@ -87,9 +89,6 @@ AC_PROG_SED
 
 dnl Check for C++11 strict conformance mode (-std=c++11)
 AX_CXX_COMPILE_STDCXX_11([noext])
-
-dnl Check for sip executable and sip include path
-AX_SIP_DEVEL
 
 dnl Check for swig
 AX_PKG_SWIG(, [], [AC_MSG_ERROR([swig is required to build])])

--- a/configure.ac
+++ b/configure.ac
@@ -45,6 +45,13 @@ esac
 dnl Automake init set-up and checks
 AM_INIT_AUTOMAKE([no-define subdir-objects foreign])
 
+# Enable static linking
+AC_ARG_ENABLE([static-link],
+    [AS_HELP_STRING([--enable-static-link],
+                    [use static link flags (default is no)])],
+    [enable_static_link=$enableval],
+    [enable_static_link=no])
+
 # Enable debug
 AC_ARG_ENABLE([debug],
     [AS_HELP_STRING([--enable-debug],
@@ -77,6 +84,12 @@ if test "x$enable_debug" = xyes; then
 else
     CFLAGS='-O2 -pipe -fPIC'
     CXXFLAGS='-O2 -pipe -fPIC'
+fi
+
+dnl Set static link flags
+if test "x$enable_static_link" = xyes; then
+    CFLAGS+=' -static-libstdc++ -static-libgcc'
+    CXXFLAGS+=' -static-libstdc++ -static-libgcc'
 fi
 
 dnl Compiler checks

--- a/cppForSwig/Makefile.am
+++ b/cppForSwig/Makefile.am
@@ -62,6 +62,10 @@ CXXCPP += -I/usr/include/c++/v1
 endif
 endif
 
+if TARGET_LINUX
+LDLIBS += -lrt
+endif
+
 # each .o file depends on all .h files
 EVERY_HEADER = bdmenums.h BDM_mainthread.h BDM_supportClasses.h BinaryData.h \
 	Blockchain.h BlockDataManagerConfig.h BlockDataViewer.h BlockObj.h \
@@ -76,7 +80,7 @@ EVERY_HEADER = bdmenums.h BDM_mainthread.h BDM_supportClasses.h BinaryData.h \
 all: ../_CppBlockUtils.so ../qrc_img_resources.py
 
 ../_CppBlockUtils.so: $(OBJS) CppBlockUtils_wrap.o
-	$(LINK) -shared -fPIC $(LDLIBS) $(LDFLAGS) $(CXXFLAGS) $(OBJS) $(STATICPYTHON) CppBlockUtils_wrap.o -o ../_CppBlockUtils.so
+	$(LINK) -shared -fPIC $(LDFLAGS) $(CXXFLAGS) $(OBJS) $(STATICPYTHON) CppBlockUtils_wrap.o $(LDLIBS) -o ../_CppBlockUtils.so
 
 ../qrc_img_resources.py: ../imgList.xml
 	$(PYRCC4) -o ../qrc_img_resources.py ../imgList.xml

--- a/dpkgfiles/make_deb_package.README
+++ b/dpkgfiles/make_deb_package.README
@@ -1,9 +1,6 @@
 Instructions for using make_deb_package.py outside of Gitian
 
 
-Note that you probably don't want to follow these instructions. Instead, you
-probably want to just run the Gitian build script to generate the deb.
-
 1) We use cowbuilder to build in a chroot, so you need to prepare a chroot with
    cowbuilder first (instructions from the Debian reproducible build project):
 
@@ -16,6 +13,9 @@ probably want to just run the Gitian build script to generate the deb.
       apt-key fingerprint | grep '49B6 5747 36D0 B637 CC37  01EA 5DB7 CA67 EA59 A31F' || { echo 'Something is wrong' && exit 1; }
       apt-get update
       apt-get upgrade
+      # next two lines required only for static linking
+      apt-get install libstdc++-4.8-pic # may vary based on version of libstdc++
+      ln -s /usr/lib/gcc/x86_64-linux-gnu/4.8/libstdc++_pic.a /usr/lib/x86_64-linux-gnu/libstdc++.a # may vary based on the chroot's triplet and the version of libstdc++
       exit 0
 
    The above instructions install the Debian reproducible build toolchain in
@@ -27,9 +27,9 @@ probably want to just run the Gitian build script to generate the deb.
 2) Make sure you have libfaketime installed on the machine you are running the
    make_deb_package.py script from (not the chroot).
 
-3) Run "python dpkgfiles/make_deb_package.py base-reproducible.cow" from the
+3) Run "python dpkgfiles/make_deb_package.py base-reproducible.cow 1" from the
    Armory root directory. Alternatively, run "make deb" after having run
-   "./configure".
+   "./configure". The "1" indicates that the build links libstdc++ statically.
 
 4) You should find the results of the build in ../armory-build/.
 

--- a/dpkgfiles/make_deb_package.README
+++ b/dpkgfiles/make_deb_package.README
@@ -29,8 +29,12 @@ Instructions for using make_deb_package.py outside of Gitian
 
 3) Run "python dpkgfiles/make_deb_package.py base-reproducible.cow amd64 1 0"
    from the Armory root directory. Alternatively, run "make deb" after having
-   run "./configure". The "1" indicates that the build links libstdc++
-   statically. Substitute i386 for amd64 for a 32-bit package.
+   run "./configure". The first parameter is the filename for the chroot in
+   /var/cache/pbuilder/. The second parameter is i386 or amd64 to indicate what
+   is the bitness of the package we are building. The third parameter is 1 or 0
+   to indicate whether to build with static libstdc++ or not. The fourth
+   parameter is 1 or 0 to indicate whether or not to build the dependencies
+   from source.
 
 4) You should find the results of the build in ../armory-build/. Doing the same
    type of build twice will overwrite the previous results (amd64 and amd64 or
@@ -39,5 +43,5 @@ Instructions for using make_deb_package.py outside of Gitian
 
 Note: These instructions have been tested on a Debian Jessie host.
 
-Note: Specify --architecture i386 to the cowbuilder --create command for a
+Note: Specify --architecture i386 to the "cowbuilder --create" command for a
       32-bit chroot for building 32-bit deb packages.

--- a/dpkgfiles/make_deb_package.README
+++ b/dpkgfiles/make_deb_package.README
@@ -27,10 +27,17 @@ Instructions for using make_deb_package.py outside of Gitian
 2) Make sure you have libfaketime installed on the machine you are running the
    make_deb_package.py script from (not the chroot).
 
-3) Run "python dpkgfiles/make_deb_package.py base-reproducible.cow 1" from the
-   Armory root directory. Alternatively, run "make deb" after having run
-   "./configure". The "1" indicates that the build links libstdc++ statically.
+3) Run "python dpkgfiles/make_deb_package.py base-reproducible.cow amd64 1 0"
+   from the Armory root directory. Alternatively, run "make deb" after having
+   run "./configure". The "1" indicates that the build links libstdc++
+   statically. Substitute i386 for amd64 for a 32-bit package.
 
-4) You should find the results of the build in ../armory-build/.
+4) You should find the results of the build in ../armory-build/. Doing the same
+   type of build twice will overwrite the previous results (amd64 and amd64 or
+   i386 and i386). However, you can do amd64 and then i386 without the i386
+   build overwriting the amd64 build result and the other way around.
 
 Note: These instructions have been tested on a Debian Jessie host.
+
+Note: Specify --architecture i386 to the cowbuilder --create command for a
+      32-bit chroot for building 32-bit deb packages.

--- a/dpkgfiles/make_deb_package.py
+++ b/dpkgfiles/make_deb_package.py
@@ -38,6 +38,8 @@ def find(name, path):
 parser = argparse.ArgumentParser()
 parser.add_argument('chroot', help='name of chroot (including .cow)')
 parser.add_argument('static', type=int, help='boolean for static build (0 or 1)')
+parser.add_argument('build_depends', metavar='build-depends', type=int, help='boolean for whether to'
+        + 'build dependencies or not (0 or 1)')
 args = parser.parse_args()
 
 if pwd().split('/')[-1]=='dpkgfiles':
@@ -107,3 +109,15 @@ for f in dpkgfiles:
 
 # Finally, all the magic happens here
 execAndWait('%s pdebuild --pbuilder cowbuilder --use-pdebuild-internal --buildresult ../armory-build -- --basepath /var/cache/pbuilder/%s' % (faketimeVars, args.chroot))
+if args.build_depends:
+    # Build all the dependencies
+    cd('..')
+    execAndWait('mkdir armory-build-depends')
+    cd('armory-build-depends')
+    depends = ['http://archive.ubuntu.com/ubuntu/pool/main/t/twisted/twisted_13.2.0-1ubuntu1.dsc', 'http://archive.ubuntu.com/ubuntu/pool/main/p/python-qt4/python-qt4_4.11.2+dfsg-1.dsc', 'http://archive.ubuntu.com/ubuntu/pool/main/s/sip4/sip4_4.16.3+dfsg-1.dsc', 'http://archive.ubuntu.com/ubuntu/pool/main/p/pyasn1/pyasn1_0.1.7-1ubuntu2.dsc', 'http://archive.ubuntu.com/ubuntu/pool/main/q/qt4-x11/qt4-x11_4.8.6+git49-gbc62005+dfsg-1ubuntu1.dsc', 'http://archive.ubuntu.com/ubuntu/pool/main/p/python-psutil/python-psutil_2.1.1-1.dsc', 'http://archive.ubuntu.com/ubuntu/pool/universe/d/dpkg-sig/dpkg-sig_0.13.1+nmu2.dsc', 'http://archive.ubuntu.com/ubuntu/pool/main/q/qt-assistant-compat/qt-assistant-compat_4.6.3-6.dsc', 'http://archive.ubuntu.com/ubuntu/pool/main/q/qtwebkit-source/qtwebkit-source_2.3.2-0ubuntu7.dsc']
+    for url in depends:
+        execAndWait('dget -x ' + url)
+    for d in dir()[1]:
+        cd(d)
+        execAndWait('pdebuild --pbuilder cowbuilder --use-pdebuild-internal --buildresult .. -- --basepath /var/cache/pbuilder/%s' % args.chroot)
+        cd('..')

--- a/dpkgfiles/make_deb_package.py
+++ b/dpkgfiles/make_deb_package.py
@@ -37,10 +37,13 @@ def find(name, path):
 
 parser = argparse.ArgumentParser()
 parser.add_argument('chroot', help='name of chroot (including .cow)')
+parser.add_argument('bitness', type=int, help='32-bit or 64-bit (32 or 64)')
 parser.add_argument('static', type=int, help='boolean for static build (0 or 1)')
 parser.add_argument('build_depends', metavar='build-depends', type=int, help='boolean for whether to'
         + 'build dependencies or not (0 or 1)')
 args = parser.parse_args()
+
+arch = {32: 'i386', 64: 'amd64'}[args.bitness]
 
 if pwd().split('/')[-1]=='dpkgfiles':
    cd('..')
@@ -76,7 +79,7 @@ if not vstr:
    exit(1)
 
 # Copy the correct control file (for 32-bit or 64-bit OS)
-osBits = platform.architecture()[0][:2]
+osBits = args.bitness
 staticStr = ''
 if args.static:
    staticStr = 'static'
@@ -108,7 +111,7 @@ for f in dpkgfiles:
    execAndWait('%s cp dpkgfiles/%s debian/%s' % (faketimeVars, f, f))
 
 # Finally, all the magic happens here
-execAndWait('%s pdebuild --pbuilder cowbuilder --use-pdebuild-internal --buildresult ../armory-build -- --basepath /var/cache/pbuilder/%s' % (faketimeVars, args.chroot))
+execAndWait('%s pdebuild --pbuilder cowbuilder --use-pdebuild-internal --architecture %s --buildresult ../armory-build -- --basepath /var/cache/pbuilder/%s' % (faketimeVars, arch, args.chroot))
 if args.build_depends:
     # Build all the dependencies
     cd('..')

--- a/dpkgfiles/make_deb_package.py
+++ b/dpkgfiles/make_deb_package.py
@@ -117,7 +117,19 @@ if args.build_depends:
     cd('..')
     execAndWait('mkdir armory-build-depends')
     cd('armory-build-depends')
-    depends = ['http://archive.ubuntu.com/ubuntu/pool/main/t/twisted/twisted_13.2.0-1ubuntu1.dsc', 'http://archive.ubuntu.com/ubuntu/pool/main/p/python-qt4/python-qt4_4.11.2+dfsg-1.dsc', 'http://archive.ubuntu.com/ubuntu/pool/main/s/sip4/sip4_4.16.3+dfsg-1.dsc', 'http://archive.ubuntu.com/ubuntu/pool/main/p/pyasn1/pyasn1_0.1.7-1ubuntu2.dsc', 'http://archive.ubuntu.com/ubuntu/pool/main/q/qt4-x11/qt4-x11_4.8.6+git49-gbc62005+dfsg-1ubuntu1.dsc', 'http://archive.ubuntu.com/ubuntu/pool/main/p/python-psutil/python-psutil_2.1.1-1.dsc', 'http://archive.ubuntu.com/ubuntu/pool/universe/d/dpkg-sig/dpkg-sig_0.13.1+nmu2.dsc', 'http://archive.ubuntu.com/ubuntu/pool/main/q/qt-assistant-compat/qt-assistant-compat_4.6.3-6.dsc', 'http://archive.ubuntu.com/ubuntu/pool/main/q/qtwebkit-source/qtwebkit-source_2.3.2-0ubuntu7.dsc']
+    twistedURL = 'http://archive.ubuntu.com/ubuntu/pool/main/t/twisted/twisted_13.2.0-1ubuntu1.dsc'
+    pythonQt4URL = 'http://archive.ubuntu.com/ubuntu/pool/main/p/python-qt4/python-qt4_4.11.2+dfsg-1.dsc'
+    sip4URL = 'http://archive.ubuntu.com/ubuntu/pool/main/s/sip4/sip4_4.16.3+dfsg-1.dsc'
+    pyasn1URL = 'http://archive.ubuntu.com/ubuntu/pool/main/p/pyasn1/pyasn1_0.1.7-1ubuntu2.dsc'
+    qt4X11URL = 'http://archive.ubuntu.com/ubuntu/pool/main/q/qt4-x11/qt4-x11_4.8.6+git49-gbc62005+dfsg-1ubuntu1.dsc'
+    pythonPsutilURL = 'http://archive.ubuntu.com/ubuntu/pool/main/p/python-psutil/python-psutil_2.1.1-1.dsc'
+    dpkgSigURL = 'http://archive.ubuntu.com/ubuntu/pool/universe/d/dpkg-sig/dpkg-sig_0.13.1+nmu2.dsc'
+    qtAssistantCompatURL = 'http://archive.ubuntu.com/ubuntu/pool/main/q/qt-assistant-compat/qt-assistant-compat_4.6.3-6.dsc'
+    qtwebkitSourceURL = 'http://archive.ubuntu.com/ubuntu/pool/main/q/qtwebkit-source/qtwebkit-source_2.3.2-0ubuntu7.dsc'
+    depends = [
+            twistedURL, pythonQt4URL, sip4URL, pyasn1URL, qt4X11URL,
+            pythonPsutilURL, dpkgSigURL, qtAssistantCompatURL, qtwebkitSourceURL
+            ]
     for url in depends:
         execAndWait('dget -x ' + url)
     for d in dir()[1]:

--- a/dpkgfiles/make_deb_package.py
+++ b/dpkgfiles/make_deb_package.py
@@ -37,6 +37,7 @@ def find(name, path):
 
 parser = argparse.ArgumentParser()
 parser.add_argument('chroot', help='name of chroot (including .cow)')
+parser.add_argument('static', type=int, help='boolean for static build (0 or 1)')
 args = parser.parse_args()
 
 if pwd().split('/')[-1]=='dpkgfiles':
@@ -74,7 +75,14 @@ if not vstr:
 
 # Copy the correct control file (for 32-bit or 64-bit OS)
 osBits = platform.architecture()[0][:2]
+staticStr = ''
+if args.static:
+   staticStr = 'static'
 shutil.copy('dpkgfiles/control%s' % (osBits), 'dpkgfiles/control')
+
+# Copy the correct rules file (for static or non-static build)
+shutil.copy('dpkgfiles/rules%s.template' % (staticStr), 'dpkgfiles/rules')
+
 dpkgfiles = ['control', 'copyright', 'postinst', 'postrm', 'rules']
 
 
@@ -98,4 +106,4 @@ for f in dpkgfiles:
    execAndWait('%s cp dpkgfiles/%s debian/%s' % (faketimeVars, f, f))
 
 # Finally, all the magic happens here
-execAndWait('%s pdebuild --pbuilder cowbuilder --buildresult ../armory-build -- --basepath /var/cache/pbuilder/%s' % (faketimeVars, args.chroot))
+execAndWait('%s pdebuild --pbuilder cowbuilder --use-pdebuild-internal --buildresult ../armory-build -- --basepath /var/cache/pbuilder/%s' % (faketimeVars, args.chroot))

--- a/dpkgfiles/postinst
+++ b/dpkgfiles/postinst
@@ -29,7 +29,7 @@ def createDesktopFile(name, idstr, arglist, toDir=''):
    deskfile.write('GenericName=Bitcoin Client\n')
    deskfile.write('Comment=Full-featured Bitcoin wallet management application\n')
    deskfile.write('Categories=Qt;Network;\n')
-   deskfile.write('Exec=/usr/bin/armory')
+   deskfile.write('Exec=python /usr/lib/armory/ArmoryQt.py')
    for a in arglist:
       deskfile.write(' --%s' % a)
    if perm_app_register:

--- a/dpkgfiles/rules.template
+++ b/dpkgfiles/rules.template
@@ -16,4 +16,3 @@ override_dh_auto_build:
 	make PYVER=python2.7
 
 override_dh_auto_test:
-

--- a/dpkgfiles/rulesstatic.template
+++ b/dpkgfiles/rulesstatic.template
@@ -1,0 +1,21 @@
+#!/usr/bin/make -f
+# -*- makefile -*-
+# Sample debian/rules that uses debhelper.
+# This file was originally written by Joey Hess and Craig Small.
+# As a special exception, when this file is copied by dh-make into a
+# dh-make output file, you may use that output file without restriction.
+# This special exception was added by Craig Small in version 0.37 of dh-make.
+
+# Uncomment this to turn on verbose mode.
+#export DH_VERBOSE=1
+
+%:
+	dh $@ --with autoreconf
+
+override_dh_auto_configure:
+	dh_auto_configure -- --enable-static-link
+
+override_dh_auto_build:
+	make PYVER=python2.7
+
+override_dh_auto_test:


### PR DESCRIPTION
This PR creates a deb package that should be installable on all Debian based Linux distros that have at least libc6 >= 2.14 (plus python >= 2.7 and the other non-versioned dependencies, but libc6 is the only one that should potentially be an issue).

I have tested installing and running the package with Debian Jessie. It should work with all Debian versions >= Jessie and all Ubuntu versions >= Precise, but it has only been tested with Jessie. It will definitely not work with Debian <= Wheezy or Ubuntu versions below Precise due to the libc6 version requirement.

This script just generates the actual Armory package. In its current state, when installing the resulting deb package, you need to either be online to fetch the dependencies, or you need to use some method of getting the dependencies from an online computer.