### PR TITLE
RPM: Add armory.spec and armory.spec.README

### DIFF
--- a/rpmfiles/armory.spec
+++ b/rpmfiles/armory.spec
@@ -1,0 +1,33 @@
+Name:     armory
+Version:  0.93.1
+Release:  1%{?dist}
+Summary:  Advanced Bitcoin Wallet Management Software
+License:  AGPLv3
+URL:      https://bitcoinarmory.com
+Source0:  https://github.com/etotheipi/BitcoinArmory/archive/v0.93.1.tar.gz
+
+%description
+Armory is advanced program for managing multiple Bitcoin wallets with the
+highest level of security available.  Use top-of-the-line wallet encryption,
+print permanent paper backups of your wallets, and store your Bitcoins on
+an offline computer for maximum security from online threats.  Armory is
+open-source software licensed under the AGPLv3.
+
+%prep
+%autosetup -n BitcoinArmory-0.93.1
+
+%build
+make %{?_smp_mflags}
+
+%install
+%make_install
+
+%files
+/usr/share/armory/*
+/usr/lib/armory/*
+/usr/bin/armory
+/usr/share/applications/armory*
+
+%changelog
+* Thu Jul 07 2011 John Smith <john@example.com> - 0.93.1-1
+- Initial RPM release

--- a/rpmfiles/armory.spec.README
+++ b/rpmfiles/armory.spec.README
@@ -1,0 +1,31 @@
+Instructions for building an RPM from armory.spec
+
+
+1) Install rpm. The package name may be different if you are not on a Debian
+   based distro. The rpm package includes rpmbuild, which is what we will be
+   using.
+
+2) Make sure you have the following directory structure under ~/rpmbuild/:
+
+   BUILD/     BUILDROOT/ RPMS/      SOURCES/   SPECS/     SRPMS/
+
+3) Download the .tar.gz from the GitHub releases page of the Armory repo. Leave
+   it as a .tar.gz and place it directly under the SOURCES directory.
+
+4) Place the armory.spec file from the directory that contains these
+   instructions in SPECS directly.
+
+5) You may need to make some changes to the spec file, particularly if the
+   version of Armory you are building is different than the version that the
+   spec file was designed to build. You will likely be able to just modify all
+   instances of the Armory version string and then be able to build
+   successfully.
+
+6) Navigate to ~/rpmbuild/SPECS/ and run rpmbuild -ba armory.spec.
+
+7) Assuming the build was successful, you should find the RPM under RPMS,
+   though it will be in a subdirectory based on the architecture it is built
+   for (like x86_64)
+
+Note: This was only tested on a Debian Jessie build system with Fedora 21 as
+      the test machine it was installed and run on.

--- a/rpmfiles/armory.spec.README
+++ b/rpmfiles/armory.spec.README
@@ -13,7 +13,8 @@ Instructions for building an RPM from armory.spec
    it as a .tar.gz and place it directly under the SOURCES directory.
 
 4) Place the armory.spec file from the directory that contains these
-   instructions in SPECS directly.
+   instructions in SPECS directly. If building 0.94 or above, place the
+   armory.spec.autotools as armory.spec.
 
 5) You may need to make some changes to the spec file, particularly if the
    version of Armory you are building is different than the version that the
@@ -28,4 +29,5 @@ Instructions for building an RPM from armory.spec
    for (like x86_64)
 
 Note: This was only tested on a Debian Jessie build system with Fedora 21 as
-      the test machine it was installed and run on.
+      the test machine it was installed and run on. The autotools version of
+      the spec is not yet tested.

--- a/rpmfiles/armory.spec.README
+++ b/rpmfiles/armory.spec.README
@@ -1,3 +1,12 @@
+***WARNING***WARNING***WARNING***WARNING***WARNING***WARNING***WARNING***
+
+This (the stuff in the rpmfiles directory) is experimental! RPM builds are not
+supported by ATI and that should be kept in mind when using them. There is no
+guarantee that RPM builds will work.
+
+***WARNING***WARNING***WARNING***WARNING***WARNING***WARNING***WARNING***
+
+
 Instructions for building an RPM from armory.spec
 
 

--- a/rpmfiles/armory.spec.autotools
+++ b/rpmfiles/armory.spec.autotools
@@ -1,0 +1,35 @@
+Name:     armory
+Version:  0.94
+Release:  1%{?dist}
+Summary:  Advanced Bitcoin Wallet Management Software
+License:  AGPLv3
+URL:      https://bitcoinarmory.com
+Source0:  https://github.com/etotheipi/BitcoinArmory/archive/v0.94.tar.gz
+
+%description
+Armory is advanced program for managing multiple Bitcoin wallets with the
+highest level of security available.  Use top-of-the-line wallet encryption,
+print permanent paper backups of your wallets, and store your Bitcoins on
+an offline computer for maximum security from online threats.  Armory is
+open-source software licensed under the AGPLv3.
+
+%prep
+%autosetup -n BitcoinArmory-0.94
+
+%build
+autoreconf
+%configure
+make %{?_smp_mflags}
+
+%install
+%make_install
+
+%files
+/usr/share/armory/*
+/usr/lib/armory/*
+/usr/bin/armory
+/usr/share/applications/armory*
+
+%changelog
+* Thu Jul 07 2011 John Smith <john@example.com> - 0.93.1-1
+- Initial RPM release


### PR DESCRIPTION
@droark 

This is an example armory.spec that can be used to build an RPM package of Armory. As it is capable of building version 0.93.1 from the GitHub tarball. It should also be capable of building previous versions by just changing all instances of the version 0.93.1 to whatever version you are trying to build.

Note that I put an armory.spec.autotools that should work with the new autotools build system, but I haven't tried building that or running it yet.

As the README says in the note at the end. I have been able to run the RPM generated on my Debian Jessie machine on a Fedora 21 system.

Since this just involves two files (the source and the spec) and one command (rpmbuild), I didn't bother trying to write a script to automate it, especially considering that there may be some slight difference that I am not aware of in the way things are to be done if building on or building for a particular platform.