### PR TITLE
Gitian

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -85,25 +85,47 @@ objc:
 	$(QMAKE) osxbuild/objc_armory/ArmoryMac.pro -o osxbuild/objc_armory/
 	$(MAKE) -C osxbuild/objc_armory/ CC="$(CC)" CXX="$(CXX)" LINK="$(LINK)"
 
+if USE_GITIAN
+Armory.app: Armory-tmp-gitian
+	rm -rf osxbuild/$@
+	cp -R osxbuild/Armory-tmp-gitian osxbuild/$@
+else
 Armory.app: Armory-tmp
 	rm -rf osxbuild/$@
 	cp -R osxbuild/Armory-tmp osxbuild/$@
+endif
 
 Armory-tmp: all osxbuild/install-py3 osxbuild/install-qt5
-	rm -rf osxbuild/Armory-tmp osxbuild/$@
-	$(MKDIR_P) osxbuild/Armory-tmp/Contents/MacOS/py
-	$(MKDIR_P) osxbuild/Armory-tmp/Contents/Frameworks
-	$(MKDIR_P) osxbuild/Armory-tmp/Contents/Resources
-	$(MKDIR_P) osxbuild/Armory-tmp/Contents/Dependencies
-	$(MAKE) DESTDIR=osxbuild/Armory-tmp/Contents/MacOS/py PREFIX=/usr install
-	cp osxbuild/Info.plist osxbuild/Armory-tmp/Contents
-	cp img/armory_icon_fullres.icns osxbuild/Armory-tmp/Contents/Resources/Icon.icns
-	cp osxbuild/Armory-script.sh osxbuild/Armory-tmp/Contents/MacOS/Armory
-	cp osxbuild/armoryd-script.sh osxbuild/Armory-tmp/Contents/MacOS/armoryd
-	cp -R osxbuild/install-py3/Python.framework osxbuild/Armory-tmp/Contents/Frameworks/
-	cp -R osxbuild/install-qt5/lib/Qt{Core,Gui,Network}.framework osxbuild/Armory-tmp/Contents/Frameworks/
-	chmod +x osxbuild/Armory-tmp/Contents/MacOS/Armory
-	chmod +x osxbuild/Armory-tmp/Contents/MacOS/armoryd
+	rm -rf osxbuild/$@
+	$(MKDIR_P) osxbuild/$@/Contents/MacOS/py
+	$(MKDIR_P) osxbuild/$@/Contents/Frameworks
+	$(MKDIR_P) osxbuild/$@/Contents/Resources
+	$(MKDIR_P) osxbuild/$@/Contents/Dependencies
+	$(MAKE) DESTDIR=osxbuild/$@/Contents/MacOS/py PREFIX=/usr install
+	cp osxbuild/Info.plist osxbuild/$@/Contents
+	cp img/armory_icon_fullres.icns osxbuild/$@/Contents/Resources/Icon.icns
+	cp osxbuild/Armory-script.sh osxbuild/$@/Contents/MacOS/Armory
+	cp osxbuild/armoryd-script.sh osxbuild/$@/Contents/MacOS/armoryd
+	cp -R osxbuild/install-py3/Python.framework osxbuild/$@/Contents/Frameworks/
+	cp -R osxbuild/install-qt5/lib/Qt{Core,Gui,Network}.framework osxbuild/$@/Contents/Frameworks/
+	chmod +x osxbuild/$@/Contents/MacOS/Armory
+	chmod +x osxbuild/$@/Contents/MacOS/armoryd
+
+Armory-tmp-gitian: all
+	rm -rf osxbuild/$@
+	$(MKDIR_P) osxbuild/$@/Contents/MacOS/py
+	$(MKDIR_P) osxbuild/$@/Contents/Frameworks
+	$(MKDIR_P) osxbuild/$@/Contents/Resources
+	$(MKDIR_P) osxbuild/$@/Contents/Dependencies
+	$(MAKE) DESTDIR=osxbuild/$@/Contents/MacOS/py PREFIX=/usr install
+	cp osxbuild/Info.plist osxbuild/$@/Contents
+	cp img/armory_icon_fullres.icns osxbuild/$@/Contents/Resources/Icon.icns
+	cp osxbuild/Armory-script.sh osxbuild/$@/Contents/MacOS/Armory
+	cp osxbuild/armoryd-script.sh osxbuild/$@/Contents/MacOS/armoryd
+	cp -R depends/x86_64-apple-darwin11/Python.framework osxbuild/$@/Contents/Frameworks/
+	cp -R depends/x86_64-apple-darwin11/lib/Qt{Core,Gui,Network}.framework osxbuild/$@/Contents/Frameworks/
+	chmod +x osxbuild/$@/Contents/MacOS/Armory
+	chmod +x osxbuild/$@/Contents/MacOS/armoryd
 
 osxbuild/install-py3:
 	@echo "building py3"

--- a/Makefile.am
+++ b/Makefile.am
@@ -46,6 +46,23 @@ install-exec-local:
 	cp BitTornado/BT1/*.py $(DESTDIR)$(PREFIX)/lib/armory/BitTornado/BT1
 	cp default_bootstrap.torrent $(DESTDIR)$(PREFIX)/lib/armory
 
+all-test-tools: all
+	$(MAKE) -C cppForSwig/gtest
+
+gtest: all-test-tools
+	(cd cppForSwig/gtest && ./CppBlockUtilsTests)
+
+pytest: all
+	python -m unittest discover
+
+test: gtest pytest
+
+mo: messages
+	$(MAKE) -C po mo
+
+messages:
+	xgettext -o po/messages.pot --from-code=UTF-8 -L Python -ktr *.py armoryengine/*.py ui/*.py
+
 if TARGET_LINUX
 if BUILD_LINUX
 deb:

--- a/build-aux/m4/ax_sip_devel.m4
+++ b/build-aux/m4/ax_sip_devel.m4
@@ -96,8 +96,11 @@ fi
 dnl this part of the code to detect python version and include path
 dnl  was taken from AX_PYTHON_DEVEL macro, (rev. 2013)
 dnl  modified by ATI
-python_path=`$PYTHON -c "import distutils.sysconfig; \
-        print (disutils.sysconfig.get_python_inc ());"`
+if test -z "$PYTHON"; then
+        AC_MSG_ERROR([python interpreter not found])
+fi
+python_path=`${PYTHON} -c "import distutils.sysconfig; \
+        print (distutils.sysconfig.get_python_inc ());"`
 for i in "$python_path/include/python$PYTHON_VERSION/" "$python_path/include/python/" "$python_path/" ; do
         python_path=`find $i -type f -name Python.h -print | sed "1q"`
         if test -n "$python_path" ; then

--- a/configure.ac
+++ b/configure.ac
@@ -99,39 +99,12 @@ AX_CXX_COMPILE_STDCXX_11([noext])
 dnl Check for swig
 AX_PKG_SWIG(, [], [AC_MSG_ERROR([swig is required to build])])
 
-dnl PyQt check
-
-AC_MSG_CHECKING([for PyQt])
-
-prog="[import sys
-try: import PyQt5
-except ImportError: sys.exit(1)
-sys.exit(0)]"
-
-${PYTHON} -c "${prog}"
-retval=$?
-
-if test $retval -ne 0; then
-    AC_MSG_RESULT([no])
-    AC_MSG_ERROR([cannot find PyQt])
-else
-    AC_MSG_RESULT([yes])
-fi
-
 dnl PyQt tools check
-
-prog="[import os, sys
-from PyQt5.QtCore import QCoreApplication
-app = QCoreApplication([])
-path = app.applicationDirPath()
-sys.stdout.write(path)]"
-
-PYPATH=`${PYTHON} -c "${prog}"`
 
 AC_ARG_VAR([PYRCC5], [PyQt5 resources compiler])
 
 if test "x$PYRCC5" = "x" ; then
-    AC_PATH_PROG([PYRCC5], [pyrcc5], [], [${PYPATH}:$PATH])
+    AC_PATH_PROG([PYRCC5], [pyrcc5], [], [$PATH])
 fi
 
 if test "x$PYRCC5" = "x"; then

--- a/configure.ac
+++ b/configure.ac
@@ -45,6 +45,13 @@ esac
 dnl Automake init set-up and checks
 AM_INIT_AUTOMAKE([no-define subdir-objects foreign])
 
+# Enable Gitian build
+AC_ARG_ENABLE([gitian],
+    [AS_HELP_STRING([--enable-gitian],
+                    [use Gitian-specific rules in Makefile (for Armory.app)])],
+    [enable_gitian=$enableval],
+    [enable_gitian=no])
+
 # Enable debug
 AC_ARG_ENABLE([debug],
     [AS_HELP_STRING([--enable-debug],
@@ -69,6 +76,7 @@ AM_CONDITIONAL([TARGET_WINDOWS], [test x$TARGET_OS = xwindows])
 AM_CONDITIONAL([BUILD_LINUX], [test x$BUILD_OS = xlinux])
 AM_CONDITIONAL([BUILD_DARWIN], [test x$BUILD_OS = xdarwin])
 AM_CONDITIONAL([BUILD_WINDOWS], [test x$BUILD_OS = xwindows])
+AM_CONDITIONAL([USE_GITIAN], [test "x$enable_gitian" = xyes])
 
 dnl Set compiler flags
 if test "x$enable_debug" = xyes; then

--- a/configure.ac
+++ b/configure.ac
@@ -58,7 +58,7 @@ AC_ARG_ENABLE([debug],
     [enable_debug=no])
 
 dnl Define variables
-AM_PATH_PYTHON([2.7])
+AM_PATH_PYTHON([3.4])
 
 PYTHON_INCLUDES=`$PYTHON-config --includes`
 PYTHON_LIBS=`$PYTHON-config --libs`
@@ -104,7 +104,7 @@ dnl PyQt check
 AC_MSG_CHECKING([for PyQt])
 
 prog="[import sys
-try: import PyQt4
+try: import PyQt5
 except ImportError: sys.exit(1)
 sys.exit(0)]"
 
@@ -121,20 +121,20 @@ fi
 dnl PyQt tools check
 
 prog="[import os, sys
-from PyQt4.QtCore import QCoreApplication
+from PyQt5.QtCore import QCoreApplication
 app = QCoreApplication([])
 path = app.applicationDirPath()
 sys.stdout.write(path)]"
 
 PYPATH=`${PYTHON} -c "${prog}"`
 
-AC_ARG_VAR([PYRCC4], [PyQt4 resources compiler])
+AC_ARG_VAR([PYRCC5], [PyQt5 resources compiler])
 
-if test "x$PYRCC4" = "x" ; then
-    AC_PATH_PROG([PYRCC4], [pyrcc4], [], [${PYPATH}:$PATH])
+if test "x$PYRCC5" = "x" ; then
+    AC_PATH_PROG([PYRCC5], [pyrcc5], [], [${PYPATH}:$PATH])
 fi
 
-if test "x$PYRCC4" = "x"; then
+if test "x$PYRCC5" = "x"; then
     AC_MSG_ERROR([cannot find PyQt dev tools])
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -18,8 +18,6 @@ case $host in
         ;;
     *darwin*)
         TARGET_OS=darwin
-        dnl Check for sip executable and sip include path
-        AX_SIP_DEVEL
         ;;
     *linux*)
         TARGET_OS=linux
@@ -141,6 +139,15 @@ if test "x$PYRCC4" = "x"; then
 fi
 
 dnl End PyQt tools check
+
+case $host in
+    *darwin*)
+        dnl Check for sip executable and sip include path
+        AX_SIP_DEVEL
+        ;;
+    *)
+        ;;
+esac
 
 AC_CONFIG_FILES([Makefile cppForSwig/Makefile])
 AC_OUTPUT

--- a/cppForSwig/Makefile.am
+++ b/cppForSwig/Makefile.am
@@ -79,7 +79,7 @@ all: ../_CppBlockUtils.so ../qrc_img_resources.py
 	$(LINK) -shared -fPIC $(LDLIBS) $(LDFLAGS) $(CXXFLAGS) $(OBJS) $(STATICPYTHON) CppBlockUtils_wrap.o -o ../_CppBlockUtils.so
 
 ../qrc_img_resources.py: ../imgList.xml
-	$(PYRCC4) -o ../qrc_img_resources.py ../imgList.xml
+	$(PYRCC5) -o ../qrc_img_resources.py ../imgList.xml
 
 
 #**************************************************************************

--- a/depends/packages/native_cctools.mk
+++ b/depends/packages/native_cctools.mk
@@ -1,0 +1,56 @@
+package=native_cctools
+$(package)_version=ee31ae567931c426136c94aad457c7b51d844beb
+$(package)_download_path=https://github.com/theuni/cctools-port/archive
+$(package)_file_name=$($(package)_version).tar.gz
+$(package)_sha256_hash=ef107e6ab1b3994cb22e14f4f5c59ea0c0b5a988e6b21d42ed9616b018bbcbf9
+$(package)_build_subdir=cctools
+$(package)_clang_version=3.6.0
+$(package)_clang_download_path=http://llvm.org/releases/$($(package)_clang_version)
+$(package)_clang_download_file=clang+llvm-$($(package)_clang_version)-x86_64-linux-gnu-ubuntu-14.04.tar.xz
+$(package)_clang_file_name=clang-llvm-$($(package)_clang_version)-x86_64-linux-gnu-ubuntu-14.04.tar.xz
+$(package)_clang_sha256_hash=e8396103fbf794e6af671593659458dfe841c32234d3cd4f37be0b48cd6a9f8b
+define $(package)_fetch_cmds
+$(call fetch_file,$(package),$($(package)_download_path),$($(package)_download_file),$($(package)_file_name),$($(package)_sha256_hash)) && \
+$(call fetch_file,$(package),$($(package)_clang_download_path),$($(package)_clang_download_file),$($(package)_clang_file_name),$($(package)_clang_sha256_hash))
+endef
+
+define $(package)_extract_cmds
+  mkdir -p toolchain/bin toolchain/lib/clang/3.6.0/include && \
+  tar --strip-components=1 -C toolchain -xf $($(package)_source_dir)/$($(package)_clang_file_name) && \
+  echo "#!/bin/sh" > toolchain/bin/$(host)-dsymutil && \
+  echo "exit 0" >> toolchain/bin/$(host)-dsymutil && \
+  chmod +x toolchain/bin/$(host)-dsymutil && \
+  tar --strip-components=1 -xf $($(package)_source)
+endef
+
+define $(package)_set_vars
+$(package)_config_opts=--target=$(host) --disable-libuuid
+$(package)_ldflags+=-Wl,-rpath=\\$$$$$$$$\$$$$$$$$ORIGIN/../lib
+$(package)_cc=$($(package)_extract_dir)/toolchain/bin/clang
+$(package)_cxx=$($(package)_extract_dir)/toolchain/bin/clang++
+endef
+
+define $(package)_preprocess_cmds
+  cd $($(package)_build_subdir); ./autogen.sh
+endef
+
+define $(package)_config_cmds
+  $($(package)_autoconf)
+endef
+
+define $(package)_build_cmds
+  $(MAKE)
+endef
+
+define $(package)_stage_cmds
+  $(MAKE) DESTDIR=$($(package)_staging_dir) install && \
+  cd $($(package)_extract_dir)/toolchain && \
+  mkdir -p $($(package)_staging_prefix_dir)/lib/clang/$($(package)_clang_version)/include && \
+  mkdir -p $($(package)_staging_prefix_dir)/bin $($(package)_staging_prefix_dir)/include && \
+  cp -P bin/clang bin/clang++ $($(package)_staging_prefix_dir)/bin/ &&\
+  cp lib/libLTO.so $($(package)_staging_prefix_dir)/lib/ && \
+  cp -rf lib/clang/$($(package)_clang_version)/include/* $($(package)_staging_prefix_dir)/lib/clang/$($(package)_clang_version)/include/ && \
+  cp bin/$(host)-dsymutil $($(package)_staging_prefix_dir)/bin && \
+  if `test -d include/c++/`; then cp -rf include/c++/ $($(package)_staging_prefix_dir)/include/; fi && \
+  if `test -d lib/c++/`; then cp -rf lib/c++/ $($(package)_staging_prefix_dir)/lib/; fi
+endef

--- a/depends/packages/native_psutil.mk
+++ b/depends/packages/native_psutil.mk
@@ -3,13 +3,13 @@ $(package)_version=2.2.1
 $(package)_download_path=https://pypi.python.org/packages/source/p/psutil
 $(package)_file_name=psutil-$($(package)_version).tar.gz
 $(package)_sha256_hash=a0e9b96f1946975064724e242ac159f3260db24ffa591c3da0a355361a3a337f
-$(package)_dependencies=native_python2
+$(package)_dependencies=native_python3
 $(package)_build_env=CC="$($(package)_cc)" LD="$($(package)_cc)" CFLAGS="$($(package)_cflags)"
 
 define $(package)_build_cmds
-  $($(package)_prefixbin)/python setup.py build
+  $($(package)_prefixbin)/python3 setup.py build
 endef
 
 define $(package)_stage_cmds
-  $($(package)_prefixbin)/python setup.py install --root=$($(package)_staging_dir) --prefix=$($(package)_prefix)
+  $($(package)_prefixbin)/python3 setup.py install --root=$($(package)_staging_dir) --prefix=$($(package)_prefix)
 endef

--- a/depends/packages/native_sip.mk
+++ b/depends/packages/native_sip.mk
@@ -3,7 +3,7 @@ $(package)_version=4.16.7
 $(package)_download_path=http://sourceforge.net/projects/pyqt/files/sip/sip-$($(package)_version)
 $(package)_file_name=sip-$($(package)_version).tar.gz
 $(package)_sha256_hash=4caa8d52e4403bae5c4c64f44de03a2cfd0bb10b6d96c5fb771133516df9abbd
-$(package)_dependencies=native_python2
+$(package)_dependencies=native_python3
 
 define $(package)_set_vars
   $(package)_config_opts=CC="$($(package)_cc)" CXX="$($(package)_cxx)" CFLAGS="$($(package)_cflags)"
@@ -12,7 +12,7 @@ define $(package)_set_vars
 endef
 
 define $(package)_config_cmds
-  $($(package)_prefixbin)/python configure.py $($(package)_config_opts)
+  $($(package)_prefixbin)/python3 configure.py $($(package)_config_opts)
 endef
 
 define $(package)_build_cmds

--- a/depends/packages/native_zope.interface.mk
+++ b/depends/packages/native_zope.interface.mk
@@ -3,8 +3,12 @@ $(package)_version=4.1.2
 $(package)_download_path=https://pypi.python.org/packages/source/z/zope.interface
 $(package)_file_name=zope.interface-$($(package)_version).tar.gz
 $(package)_sha256_hash=441fefcac1fbac57c55239452557d3598571ab82395198b2565a29d45d1232f6
-$(package)_dependencies=native_python2
+$(package)_dependencies=native_python3
+
+define $(package)_build_cmds
+  $($(package)_prefixbin)/python3 setup.py build
+endef
 
 define $(package)_stage_cmds
-  $($(package)_prefixbin)/python setup.py install --prefix=$($(package)_staging_prefix_dir)
+  $($(package)_prefixbin)/python3 setup.py install --root=$($(package)_staging_dir) --prefix=$($(package)_prefix)
 endef

--- a/depends/packages/openssl.mk
+++ b/depends/packages/openssl.mk
@@ -1,9 +1,9 @@
 # Pretty much taken verbatim from Bitcoin Core
 package=openssl
-$(package)_version=1.0.1k
+$(package)_version=1.0.1m
 $(package)_download_path=https://www.openssl.org/source
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_sha256_hash=8f9faeaebad088e772f4ef5e38252d472be4d878c6b3a2718c10a4fcebe7a41c
+$(package)_sha256_hash=095f0b7b09116c0c5526422088058dc7e6e000aa14d22acca6a4e2babcdfef74
 
 define $(package)_set_vars
 $(package)_config_env=AR="$($(package)_ar)" RANLIB="$($(package)_ranlib)" CC="$($(package)_cc)"

--- a/depends/packages/openssl.mk
+++ b/depends/packages/openssl.mk
@@ -3,7 +3,7 @@ package=openssl
 $(package)_version=1.0.1k
 $(package)_download_path=https://www.openssl.org/source
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_sha256_hash=095f0b7b09116c0c5526422088058dc7e6e000aa14d22acca6a4e2babcdfef74
+$(package)_sha256_hash=8f9faeaebad088e772f4ef5e38252d472be4d878c6b3a2718c10a4fcebe7a41c
 
 define $(package)_set_vars
 $(package)_config_env=AR="$($(package)_ar)" RANLIB="$($(package)_ranlib)" CC="$($(package)_cc)"

--- a/depends/packages/openssl.mk
+++ b/depends/packages/openssl.mk
@@ -1,6 +1,6 @@
 # Pretty much taken verbatim from Bitcoin Core
 package=openssl
-$(package)_version=1.0.1m
+$(package)_version=1.0.1k
 $(package)_download_path=https://www.openssl.org/source
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_sha256_hash=095f0b7b09116c0c5526422088058dc7e6e000aa14d22acca6a4e2babcdfef74

--- a/depends/packages/packages.mk
+++ b/depends/packages/packages.mk
@@ -1,10 +1,14 @@
 # zip is currently broken. Add it back to packages when it is fixed.
-packages:=openssl pyqt4 twisted
-native_packages := native_pcre native_psutil native_python2 native_rsync native_sip native_swig native_zlib native_zope.interface
+packages:=openssl pyqt5 python3 twisted
+native_packages := native_pcre native_psutil native_python3 native_rsync native_sip native_swig native_zlib native_zope.interface
 
 qt_native_packages = native_protobuf
 qt_packages = qrencode protobuf
 
-qt_linux_packages= qt48 expat dbus libxcb xcb_proto libXau xproto freetype fontconfig libX11 xextproto libXext xtrans libICE libSM
-qt_darwin_packages=qt48
-qt_mingw32_packages=qt48
+qt_linux_packages= qt expat dbus libxcb xcb_proto libXau xproto freetype fontconfig libX11 xextproto libXext xtrans
+qt_darwin_packages=qt
+qt_mingw32_packages=qt
+
+ifneq ($(build_os),darwin)
+darwin_native_packages=native_cctools
+endif

--- a/depends/packages/pyqt5.mk
+++ b/depends/packages/pyqt5.mk
@@ -5,10 +5,13 @@ $(package)_file_name=PyQt-gpl-$($(package)_version).tar.gz
 $(package)_mingw32_file_name=PyQt-gpl-$($(package)_version).tar.gz
 $(package)_sha256_hash=c6c33f392c0a2b0c9ec16531dc88fa9aee853e9fff10f0ad9d0e4777629fe79e
 $(package)_mingw32_sha256_hash=39fe23844b08f67833581f98dbe5cf9de501785a0af1176e3e8046a9fb28a247
-$(package)_dependencies=native_python3 qt native_sip
+$(package)_dependencies=native_python3 python3 qt native_sip
+$(package)_patches=darwin.cfg
 
 define $(package)_config_cmds
-  $($(package)_prefix)/native/bin/python3 configure.py --confirm-license --sip=$($(package)_prefix)/native/bin/sip
+  sed -i.old "1s|^|install_sysroot = $(host_prefix)\n|" $($(package)_patch_dir)/darwin.cfg && \
+  sed -i.old "s|if 'linux' in target_config.qmake_spec|if 'linux' in target_config.qmake_spec and 'mac' not in target_config.qmake_spec|" configure.py && \
+  $($(package)_prefix)/native/bin/python3 configure.py --confirm-license --qmake=$($(package)_prefix)/native/bin/qmake --sip=$($(package)_prefix)/native/bin/sip --sip-incdir=$($(package)_prefix)/native/include/python3.4m --configuration=$($(package)_patch_dir)/darwin.cfg --sysroot=$($(package)_prefix) --spec=macx-clang-linux
 endef
 
 define $(package)_build_cmds
@@ -16,5 +19,5 @@ define $(package)_build_cmds
 endef
 
 define $(package)_stage_cmds
-  $(MAKE) DESTDIR=$($(package)_staging_dir) install
+  $(MAKE) INSTALL_ROOT=$($(package)_staging_dir) install
 endef

--- a/depends/packages/python3.mk
+++ b/depends/packages/python3.mk
@@ -1,0 +1,31 @@
+package=python3
+$(package)_version=3.4.3
+$(package)_download_path=https://www.python.org/ftp/python/$($(package)_version)
+$(package)_file_name=Python-$($(package)_version).tgz
+$(package)_sha256_hash=8b743f56e9e50bf0923b9e9c45dd927c071d7aa56cd46569d8818add8cf01147
+$(package)_patches=0010-cross-darwin-feature.patch
+
+define $(package)_set_vars
+$(package)_config_env_darwin=READELF="x86_64-apple-darwin11-otool" CONFIG_SITE=config.site MACOSX_DEPLOYMENT_TARGET=10.7
+$(package)_config_opts_darwin = --disable-ipv6 --without-ensurepip --enable-framework=$(host_prefix)
+endef
+
+define $(package)_preprocess_cmds
+  echo "ac_cv_file__dev_ptmx=no" > config.site && \
+  echo "ac_cv_file__dev_ptc=no" >> config.site && \
+  patch -p1 --ignore-whitespace < $($(package)_patch_dir)/0010-cross-darwin-feature.patch && \
+  autoreconf && \
+  sed -i.old "/frameworkinstallapps:/,+1d" Makefile.pre.in
+endef
+
+define $(package)_config_cmds
+  $($(package)_autoconf) --build=$(BUILD)
+endef
+
+define $(package)_build_cmds
+  $(MAKE)
+endef
+
+define $(package)_stage_cmds
+  $(MAKE) DESTDIR=$($(package)_staging_dir) STRIPFLAG="-s --strip-program=x86_64-apple-darwin11-strip" install
+endef

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -6,32 +6,19 @@ $(package)_file_name=$(package)-everywhere-opensource-src-$($(package)_version).
 $(package)_sha256_hash=84e924181d4ad6db00239d87250cc89868484a14841f77fb85ab1f1dbdcd7da1
 $(package)_dependencies=openssl
 $(package)_linux_dependencies=freetype fontconfig dbus libxcb libX11 xproto libXext
-$(package)_build_subdir=qtbase
-$(package)_qt_libs=corelib network widgets gui plugins testlib
+$(package)_qt_libs=corelib network gui
 $(package)_patches=mac-qmake.conf fix-xcb-include-order.patch qt5-tablet-osx.patch qt5-yosemite.patch
 
 define $(package)_set_vars
 $(package)_config_opts_release = -release
 $(package)_config_opts_debug   = -debug
-$(package)_config_opts += -opensource -confirm-license -no-audio-backend -no-sql-tds -no-glib -no-icu
-$(package)_config_opts += -no-cups -no-iconv -no-gif -no-audio-backend -no-freetype
-$(package)_config_opts += -no-sql-sqlite -no-nis -no-cups -no-iconv -no-pch
-$(package)_config_opts += -no-gif -no-feature-style-plastique
-$(package)_config_opts += -no-qml-debug -no-pch -no-nis -nomake examples -nomake tests
-$(package)_config_opts += -no-feature-style-cde -no-feature-style-s60 -no-feature-style-motif
-$(package)_config_opts += -no-feature-style-windowsmobile -no-feature-style-windowsce
-$(package)_config_opts += -no-feature-style-cleanlooks
+$(package)_config_opts += -opensource -confirm-license
+$(package)_config_opts += -nomake examples -nomake tests
 $(package)_config_opts += -no-sql-db2 -no-sql-ibase -no-sql-oci -no-sql-tds -no-sql-mysql
 $(package)_config_opts += -no-sql-odbc -no-sql-psql -no-sql-sqlite -no-sql-sqlite2
-$(package)_config_opts += -skip qtsvg -skip qtwebkit -skip qtwebkit-examples -skip qtserialport
-$(package)_config_opts += -skip qtdeclarative -skip qtmultimedia -skip qtimageformats -skip qtx11extras
-$(package)_config_opts += -skip qtlocation -skip qtsensors -skip qtquick1 -skip qtxmlpatterns
-$(package)_config_opts += -skip qtquickcontrols -skip qtactiveqt -skip qtconnectivity -skip qtmacextras
-$(package)_config_opts += -skip qtwinextras -skip qtxmlpatterns -skip qtscript -skip qtdoc
 
 $(package)_config_opts += -prefix $(host_prefix) -bindir $(build_prefix)/bin
-$(package)_config_opts += -no-c++11 -openssl-linked  -v -static -silent -pkg-config
-$(package)_config_opts += -qt-libpng -qt-libjpeg -qt-zlib -qt-pcre
+$(package)_config_opts += -system-zlib -v -silent -pkg-config
 
 ifneq ($(build_os),darwin)
 	$(package)_config_opts_darwin = -xplatform macx-clang-linux -device-option MAC_SDK_PATH=$(OSX_SDK) -device-option CROSS_COMPILE="$(host)-"
@@ -46,7 +33,6 @@ $(package)_build_env  = QT_RCC_TEST=1
 endef
 
 define $(package)_preprocess_cmds
-  sed -i.old "s|updateqm.commands = \$$$$\$$$$LRELEASE|updateqm.commands = $($(package)_extract_dir)/qttools/bin/lrelease|" qttranslations/translations/translations.pro && \
   sed -i.old "s/src_plugins.depends = src_sql src_xml src_network/src_plugins.depends = src_xml src_network/" qtbase/src/src.pro && \
   sed -i.old "/XIproto.h/d" qtbase/src/plugins/platforms/xcb/qxcbxsettings.cpp && \
   sed -i.old 's/if \[ "$$$$XPLATFORM_MAC" = "yes" \]; then xspecvals=$$$$(macSDKify/if \[ "$$$$BUILD_ON_MAC" = "yes" \]; then xspecvals=$$$$(macSDKify/' qtbase/configure && \
@@ -55,9 +41,6 @@ define $(package)_preprocess_cmds
   cp -f qtbase/mkspecs/macx-clang/Info.plist.app qtbase/mkspecs/macx-clang-linux/ &&\
   cp -f qtbase/mkspecs/macx-clang/qplatformdefs.h qtbase/mkspecs/macx-clang-linux/ &&\
   cp -f $($(package)_patch_dir)/mac-qmake.conf qtbase/mkspecs/macx-clang-linux/qmake.conf && \
-  patch -p1 < $($(package)_patch_dir)/fix-xcb-include-order.patch && \
-  patch -p1 < $($(package)_patch_dir)/qt5-tablet-osx.patch && \
-  patch -d qtbase -p1 < $($(package)_patch_dir)/qt5-yosemite.patch && \
   echo "QMAKE_CFLAGS     += $($(package)_cflags) $($(package)_cppflags)" >> qtbase/mkspecs/common/gcc-base.conf && \
   echo "QMAKE_CXXFLAGS   += $($(package)_cxxflags) $($(package)_cppflags)" >> qtbase/mkspecs/common/gcc-base.conf && \
   echo "QMAKE_LFLAGS     += $($(package)_ldflags)" >> qtbase/mkspecs/common/gcc-base.conf && \
@@ -72,29 +55,14 @@ define $(package)_config_cmds
   export PKG_CONFIG_PATH=$(host_prefix)/share/pkgconfig  && \
   export CPATH=$(host_prefix)/include && \
   ./configure $($(package)_config_opts) && \
-  $(MAKE) sub-src-clean && \
-  cd ../qttranslations && ../qtbase/bin/qmake qttranslations.pro -o Makefile && \
-  cd translations && ../../qtbase/bin/qmake translations.pro -o Makefile && cd ../.. &&\
-  cd qttools/src/linguist/lrelease/ && ../../../../qtbase/bin/qmake lrelease.pro -o Makefile
+  sed -i.old "1s|^|export INSTALL_ROOT=$($(package)_staging_dir)\n|" Makefile
 endef
 
 define $(package)_build_cmds
-  export CPATH=$(host_prefix)/include && \
-  $(MAKE) -C src $(addprefix sub-,$($(package)_qt_libs)) && \
-  $(MAKE) -C ../qttools/src/linguist/lrelease && \
-  $(MAKE) -C ../qttranslations
+export CPATH=$(host_prefix)/include && \
+  $(MAKE)
 endef
 
 define $(package)_stage_cmds
-  $(MAKE) -C src INSTALL_ROOT=$($(package)_staging_dir) $(addsuffix -install_subtargets,$(addprefix sub-,$($(package)_qt_libs))) && cd .. &&\
-  $(MAKE) -C qttools/src/linguist/lrelease INSTALL_ROOT=$($(package)_staging_dir) install_target && \
-  $(MAKE) -C qttranslations INSTALL_ROOT=$($(package)_staging_dir) install_subtargets && \
-  if `test -f qtbase/src/plugins/platforms/xcb/xcb-static/libxcb-static.a`; then \
-    cp qtbase/src/plugins/platforms/xcb/xcb-static/libxcb-static.a $($(package)_staging_prefix_dir)/lib; \
-  fi
-endef
-
-define $(package)_postprocess_cmds
-  rm -rf mkspecs/ lib/cmake/ && \
-  rm lib/libQt5Bootstrap.a lib/lib*.la lib/*.prl plugins/*/*.prl
+  $(MAKE) install
 endef

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -16,6 +16,14 @@ $(package)_config_opts += -opensource -confirm-license
 $(package)_config_opts += -nomake examples -nomake tests
 $(package)_config_opts += -no-sql-db2 -no-sql-ibase -no-sql-oci -no-sql-tds -no-sql-mysql
 $(package)_config_opts += -no-sql-odbc -no-sql-psql -no-sql-sqlite -no-sql-sqlite2
+$(package)_config_opts += -skip qtandroidextras -skip qtconnectivity
+$(package)_config_opts += -skip qtdeclarative -skip qtdoc -skip qtgraphicaleffects
+$(package)_config_opts += -skip qtimageformats -skip qtlocation -skip qtmultimedia
+$(package)_config_opts += -skip qtquick1 -skip qtquickcontrols -skip qtscript
+$(package)_config_opts += -skip qtsensors -skip qtserialport -skip qtsvg
+$(package)_config_opts += -skip qttools -skip qttranslations
+$(package)_config_opts += -skip qtwinextras -skip qtx11extras -skip qtxmlpatterns
+$(package)_config_opts += -no-sse4.1 -no-sse4.2 -no-avx -no-avx2
 
 $(package)_config_opts += -prefix $(host_prefix) -bindir $(build_prefix)/bin
 $(package)_config_opts += -system-zlib -v -silent -pkg-config

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -23,6 +23,8 @@ $(package)_config_opts += -skip qtquick1 -skip qtquickcontrols -skip qtscript
 $(package)_config_opts += -skip qtsensors -skip qtserialport -skip qtsvg
 $(package)_config_opts += -skip qttools -skip qttranslations
 $(package)_config_opts += -skip qtwinextras -skip qtx11extras -skip qtxmlpatterns
+
+# NB: Due to minimum Mac requirements, disable post-SSE3 assembly.
 $(package)_config_opts += -no-sse4.1 -no-sse4.2 -no-avx -no-avx2
 
 $(package)_config_opts += -prefix $(host_prefix) -bindir $(build_prefix)/bin

--- a/depends/packages/twisted.mk
+++ b/depends/packages/twisted.mk
@@ -3,13 +3,13 @@ $(package)_version=15.0.0
 $(package)_download_path=https://pypi.python.org/packages/source/T/Twisted
 $(package)_file_name=Twisted-$($(package)_version).tar.bz2
 $(package)_sha256_hash=ac609262253057cf2aeb9dc049ba7877d646f31b4caef06a50189a023df46b51
-$(package)_dependencies=native_python2 native_zope.interface
-$(package)_build_env=CC="$($(package)_cc)" LD="$($(package)_cc)" CFLAGS="$($(package)_cflags)"
+$(package)_dependencies=python3 native_python3 native_zope.interface
+$(package)_build_env=CC="$($(package)_cc)" LD="$($(package)_cc)" LDSHARED="$($(package)_cc) -shared" CFLAGS="$($(package)_cflags)" LDFLAGS="$($(package)_ldflags)"
 
 define $(package)_build_cmds
-  $($(package)_prefix)/native/bin/python setup.py build
+  $($(package)_prefix)/native/bin/python3 setup.py build
 endef
 
 define $(package)_stage_cmds
-  $($(package)_prefix)/native/bin/python setup.py install --root=$($(package)_staging_dir) --prefix=$($(package)_prefix)
+  $($(package)_prefix)/native/bin/python3 setup.py install --root=$($(package)_staging_dir) --prefix=$($(package)_prefix)
 endef

--- a/depends/patches/pyqt5/darwin.cfg
+++ b/depends/patches/pyqt5/darwin.cfg
@@ -1,0 +1,18 @@
+# The target Python installation.
+py_platform = darwin
+py_inc_dir = %(sysroot)/Python.framework/Versions/%(py_major).%(py_minor)/include/python%(py_major).%(py_minor)m
+py_pylib_dir = %(sysroot)/Python.framework/Versions/%(py_major).%(py_minor)/lib/python%(py_major).%(py_minor)/config-%(py_major).%(py_minor)m
+py_pylib_lib = python%(py_major).%(py_minor)m
+
+# The target PyQt installation.
+pyqt_module_dir = %(install_sysroot)/Python.framework/Versions/%(py_major).%(py_minor)/lib/python%(py_major).%(py_minor)/site-packages
+pyqt_bin_dir = %(install_sysroot)/bin
+pyqt_sip_dir = %(install_sysroot)/share/sip/PyQt5
+pyuic_interpreter = %(install_sysroot)/Python.framework/Versions/%(py_major).%(py_minor)/bin/python%(py_major).%(py_minor)
+pyqt_disabled_features = PyQt_Desktop_OpenGL PyQt_qreal_double
+
+# Qt configuration common to all versions.
+qt_shared = True
+
+[Qt 5.2]
+pyqt_modules = QtCore QtGui QtNetwork

--- a/depends/patches/python3/0010-cross-darwin-feature.patch
+++ b/depends/patches/python3/0010-cross-darwin-feature.patch
@@ -1,0 +1,120 @@
+diff -urN a-3.4.x/configure.ac b-3.4.x/configure.ac
+--- a-3.4.x/configure.ac	2012-10-21 12:46:03.203791103 +0100
++++ b-3.4.x/configure.ac	2012-10-21 12:48:08.000000000 +0100
+@@ -334,6 +334,7 @@
+ then
+     # avoid using uname for cross builds
+     if test "$cross_compiling" = yes; then
++       ac_sys_release=
+        # ac_sys_system and ac_sys_release are used for setting
+        # a lot of different things including 'define_xopen_source'
+        # in the case statement below.
+@@ -344,12 +345,32 @@
+ 	*-*-cygwin*)
+ 		ac_sys_system=Cygwin
+ 		;;
++	*-*-darwin*)
++		ac_sys_system=Darwin
++		ac_sys_release=$(echo $host | sed -n 's/.*-[^0-9]\+\([0-9]\+\)/\1/p')
++		if test -z "$ac_sys_release"; then
++			# A reasonable default.
++			ac_sys_release=11
++		fi
++		# Use the last released version number for old versions.
++	        if test "$ac_sys_release" = "9" ; then
++			ac_sys_release=9.8
++	        elif test "$ac_sys_release" = "10" ; then
++			ac_sys_release=10.8
++	        elif test "$ac_sys_release" = "11" ; then
++			ac_sys_release=11.4.0
++	        elif test "$ac_sys_release" = "12" ; then
++			ac_sys_release=12.0.0
++		else
++		# ..and .0.0 for unknown versions.
++			ac_sys_release=${ac_sys_release}.0.0
++		fi
++		;;
+ 	*)
+ 		# for now, limit cross builds to known configurations
+ 		MACHDEP="unknown"
+ 		AC_MSG_ERROR([cross build not supported for $host])
+ 	esac
+-	ac_sys_release=
+     else
+ 	ac_sys_system=`uname -s`
+ 	if test "$ac_sys_system" = "AIX" \
+@@ -389,6 +410,9 @@
+ 	*-*-cygwin*)
+ 		_host_cpu=
+ 		;;
++	*-*-darwin*)
++		_host_cpu=
++		;;
+ 	*)
+ 		# for now, limit cross builds to known configurations
+ 		MACHDEP="unknown"
+@@ -1098,6 +1122,26 @@
+ 
+ AC_SUBST(BASECFLAGS)
+ 
++if test "x$cross_compiling" = xyes; then
++    function cross_arch
++    {
++        case $host in
++	  x86_64*darwin*)
++	    echo i386
++          ;;
++	  x86_64*)
++            echo x86_64
++	  ;;
++	  *)
++            echo i386
++	  ;;
++	esac
++    }
++    ARCH_PROG=cross_arch
++else
++    ARCH_PROG=/usr/bin/arch
++fi
++
+ # The -arch flags for universal builds on OSX
+ UNIVERSAL_ARCH_FLAGS=
+ AC_SUBST(UNIVERSAL_ARCH_FLAGS)
+@@ -1261,9 +1305,9 @@
+ 				    cur_target='10.5'
+                    ;;
+ 			    esac
+ 		    else
+-			    if test `/usr/bin/arch` = "i386"
++			    if test "$($ARCH_PROG)" = "i386"
+                then
+ 				    # 10.4 was the first release to support Intel archs
+ 				    cur_target="10.4"
+ 				fi
+@@ -1762,7 +1806,7 @@
+     if test "${enable_universalsdk}"; then
+ 	    :
+     else
+-        LIBTOOL_CRUFT="${LIBTOOL_CRUFT} -arch_only `/usr/bin/arch`"
++        LIBTOOL_CRUFT="${LIBTOOL_CRUFT} -arch_only $($ARCH_PROG)"
+     fi
+     LIBTOOL_CRUFT=$LIBTOOL_CRUFT' -install_name $(PYTHONFRAMEWORKINSTALLDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'
+     LIBTOOL_CRUFT=$LIBTOOL_CRUFT' -compatibility_version $(VERSION) -current_version $(VERSION)';;
+@@ -1787,7 +1831,7 @@
+     ]])],[ac_osx_32bit=yes],[ac_osx_32bit=no],[ac_osx_32bit=yes])
+     
+     if test "${ac_osx_32bit}" = "yes"; then
+-    	case `/usr/bin/arch` in
++    	case $($ARCH_PROG) in
+     	i386) 
+     		MACOSX_DEFAULT_ARCH="i386" 
+     		;;
+@@ -1799,7 +1843,7 @@
+     		;;
+     	esac
+     else
+-    	case `/usr/bin/arch` in
++    	case $($ARCH_PROG) in
+     	i386) 
+     		MACOSX_DEFAULT_ARCH="x86_64" 
+     		;;

--- a/depends/patches/qt/mac-qmake.conf
+++ b/depends/patches/qt/mac-qmake.conf
@@ -1,6 +1,6 @@
 # Needs to be reviewed once OS X support is added
 MAKEFILE_GENERATOR = UNIX
-CONFIG += app_bundle incremental global_init_link_order lib_version_first plugin_no_soname absolute_library_soname
+CONFIG += app_bundle incremental global_init_link_order lib_version_first plugin_no_soname
 QMAKE_INCREMENTAL_STYLE = sublib
 include(../common/macx.conf)
 include(../common/gcc-base-mac.conf)
@@ -13,6 +13,7 @@ QMAKE_MACOSX_DEPLOYMENT_TARGET = $${MAC_MIN_VERSION}
 QMAKE_MAC_SDK=macosx
 QMAKE_MAC_SDK.macosx.path = $$QMAKE_MAC_SDK_PATH
 QMAKE_MAC_SDK.macosx.platform_name = macosx
+QMAKE_MAC_SDK.macosx.version = 10.9
 QMAKE_CFLAGS += -target $${MAC_TARGET}
 QMAKE_OBJECTIVE_CFLAGS += $$QMAKE_CFLAGS
 QMAKE_CXXFLAGS += $$QMAKE_CFLAGS


### PR DESCRIPTION
@droark 

This PR aims to allow reproducible building of Armory.app using Gitian.

Currently all the dependencies build using Gitian, but when Armory's configure script runs, it cannot find PyQt. The issue is that there are two Pythons (one for the host and one for the build system). The PyQt check tries to run the python interpreter and import PyQt to see if it can be done successfully. The issue is that we run the build Python, while PyQt is only available to the host Python, which we can't run on the build system. I think the best solution is to only run the check if the build system architecture is the same as that of the host system, if we run the check at all.