### PR TITLE
Gitian: Add initial raspi descriptor

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -60,9 +60,17 @@ AC_ARG_ENABLE([debug],
 dnl Define variables
 AM_PATH_PYTHON([3.4])
 
-PYTHON_INCLUDES=`$PYTHON-config --includes`
-PYTHON_LIBS=`$PYTHON-config --libs`
+AC_ARG_VAR([PYTHON_INCLUDES], [Python includes (-I/usr/include/python3.4 -I/usr/include/$host/python3.4])
 
+if test "x$PYTHON_INCLUDES" = "x" ; then
+    PYTHON_INCLUDES=`$PYTHON-config --includes`
+fi
+
+AC_ARG_VAR([PYTHON_LIBS], [Python libraries (-lpython3.4)])
+
+if test "x$PYTHON_LIBS" = "x" ; then
+    PYTHON_LIBS=`$PYTHON-config --libs`
+fi
 
 dnl Make variables available to Makefiles
 AC_SUBST(PYTHON_INCLUDES)

--- a/cppForSwig/cryptopp/Makefile
+++ b/cppForSwig/cryptopp/Makefile
@@ -37,6 +37,7 @@ IS_SUN_CC = $(shell $(CXX) -V 2>&1 | $(EGREP) -c "CC: Sun")
 GAS210_OR_LATER = $(shell echo "" | $(AS) -v 2>&1 | $(EGREP) -c "GNU assembler version (2\.[1-9][0-9]|[3-9])")
 GAS217_OR_LATER = $(shell echo "" | $(AS) -v 2>&1 | $(EGREP) -c "GNU assembler version (2\.1[7-9]|2\.[2-9]|[3-9])")
 GAS219_OR_LATER = $(shell echo "" | $(AS) -v 2>&1 | $(EGREP) -c "GNU assembler version (2\.19|2\.[2-9]|[3-9])")
+XCOMPILE = $(shell $(CXX) --version 2>&1 | $(EGREP) -c "crosstool-NG")
 ISMINGW = $(shell $(CXX) --version 2>&1 | $(EGREP) -c "mingw")
 
 ifneq ($(GCC42_OR_LATER),0)
@@ -68,7 +69,11 @@ else
 ifeq ($(GAS219_OR_LATER),0)
 CXXFLAGS += -DCRYPTOPP_DISABLE_AESNI
 else
+ifeq ($(XCOMPILE),0)
 CXXFLAGS += -mpclmul -mssse3 -maes -msse4
+else
+CXXFLAGS +=
+endif
 endif
 
 endif

--- a/gitian-descriptors/bitcoin-armory-raspi.yml
+++ b/gitian-descriptors/bitcoin-armory-raspi.yml
@@ -58,13 +58,13 @@ script: |
       make ${MAKEOPTS} -C ${BASEPREFIX} HOST="${i}"
     done
 
-    # Create pyrcc4 faketime wrapper
-    echo '#!/bin/bash' > ${WRAP_DIR}/pyrcc4
-    echo "REAL=${BASEPREFIX}/`echo '${HOSTS} | awk '{print $1;}''`/bin/pyrcc4" >> ${WRAP_DIR}/pyrcc4
-    echo 'export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/faketime/libfaketime.so.1' >> ${WRAP_DIR}/pyrcc4
-    echo "export FAKETIME=\"${REFERENCE_DATETIME}\"" >> ${WRAP_DIR}/pyrcc4
-    echo "\$REAL \$@" >> $WRAP_DIR/pyrcc4
-    chmod +x ${WRAP_DIR}/pyrcc4
+    # Create pyrcc5 faketime wrapper
+    echo '#!/bin/bash' > ${WRAP_DIR}/pyrcc5
+    echo "REAL=${BASEPREFIX}/`echo '${HOSTS} | awk '{print $1;}''`/bin/pyrcc5" >> ${WRAP_DIR}/pyrcc5
+    echo 'export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/faketime/libfaketime.so.1' >> ${WRAP_DIR}/pyrcc5
+    echo "export FAKETIME=\"${REFERENCE_DATETIME}\"" >> ${WRAP_DIR}/pyrcc5
+    echo "\$REAL \$@" >> $WRAP_DIR/pyrcc5
+    chmod +x ${WRAP_DIR}/pyrcc5
 
     for i in $HOSTS; do
       export PATH=/home/ubuntu/tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/bin/:${BASEPREFIX}/${i}/bin:${BASEPREFIX}/${i}/native/bin:${ORIGPATH}

--- a/gitian-descriptors/bitcoin-armory-raspi.yml
+++ b/gitian-descriptors/bitcoin-armory-raspi.yml
@@ -1,0 +1,80 @@
+# This Gitian descriptor is currently untested.
+---
+name: "bitcoin-armory-raspi"
+enable_cache: true
+suites:
+- "trusty"
+architectures:
+- "amd64"
+packages:
+- "autoconf"
+- "automake"
+- "faketime"
+- "libtool"
+- "pkg-config"
+reference_datetime: "2013-06-01 00:00:00"
+remotes:
+- "url": "https://github.com/etotheipi/BitcoinArmory.git"
+  "dir": "BitcoinArmory"
+files: []
+script: |
+    HOSTS="arm-linux-gnueabihf"
+
+    export TZ=UTC
+
+    export GZIP="-9n"
+    export TAR_OPTIONS="--mtime="$REFERENCE_DATE\\\ $REFERENCE_TIME""
+
+    WRAP_DIR=$HOME/wrapped
+    FAKETIME_PROGS="date ar ranlib nm strip"
+    mkdir -p ${WRAP_DIR}
+    if test -n "$GBUILD_CACHE_ENABLED"; then
+      export SOURCES_PATH=${GBUILD_COMMON_CACHE}
+      export BASE_CACHE=${GBUILD_PACKAGE_CACHE}
+      mkdir -p ${BASE_CACHE} ${SOURCES_PATH}
+    fi
+
+    # Create global faketime wrappers
+    for prog in ${FAKETIME_PROGS}; do
+      echo '#!/bin/bash' > ${WRAP_DIR}/${prog}
+      echo "REAL=\`which -a ${prog} | grep -v ${WRAP_DIR}/${prog} | head -1\`" >> ${WRAP_DIR}/${prog}
+      echo 'export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/faketime/libfaketime.so.1' >> ${WRAP_DIR}/${prog}
+      echo "export FAKETIME=\"${REFERENCE_DATETIME}\"" >> ${WRAP_DIR}/${prog}
+      echo "\$REAL \$@" >> $WRAP_DIR/${prog}
+      chmod +x ${WRAP_DIR}/${prog}
+    done
+    export PATH=${WRAP_DIR}:${PATH}
+
+    git clone https://github.com/raspberrypi/tools.git
+    wget https://archive.raspbian.org/raspbian/pool/main/p/python3.4/libpython3.4-dev_3.4.3-7_armhf.deb
+    wget https://archive.raspbian.org/raspbian/pool/main/p/python3.4/libpython3.4-minimal_3.4.3-7_armhf.deb
+    dpkg-deb -x libpython3.4-dev_3.4.3-7_armhf.deb .
+    dpkg-deb -x libpython3.4-minimal_3.4.3-7_armhf.deb .
+
+    cd BitcoinArmory
+    BASEPREFIX=`pwd`/depends    
+    ORIGPATH="$PATH"
+    for i in $HOSTS; do
+      make ${MAKEOPTS} -C ${BASEPREFIX} HOST="${i}"
+    done
+
+    # Create pyrcc4 faketime wrapper
+    echo '#!/bin/bash' > ${WRAP_DIR}/pyrcc4
+    echo "REAL=${BASEPREFIX}/`echo '${HOSTS} | awk '{print $1;}''`/bin/pyrcc4" >> ${WRAP_DIR}/pyrcc4
+    echo 'export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/faketime/libfaketime.so.1' >> ${WRAP_DIR}/pyrcc4
+    echo "export FAKETIME=\"${REFERENCE_DATETIME}\"" >> ${WRAP_DIR}/pyrcc4
+    echo "\$REAL \$@" >> $WRAP_DIR/pyrcc4
+    chmod +x ${WRAP_DIR}/pyrcc4
+
+    for i in $HOSTS; do
+      export PATH=/home/ubuntu/tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/bin/:${BASEPREFIX}/${i}/bin:${BASEPREFIX}/${i}/native/bin:${ORIGPATH}
+
+      ./autogen.sh
+      ./configure --prefix=${BASEPREFIX}/${i} --host ${i} --enable-gitian PYTHON_INCLUDES="-I/home/ubuntu/usr/include/python3.4m -I/home/ubuntu/usr/include" PYTHON_LIBS="-L/home/ubuntu/usr/lib/${i} -lpython3.4m"
+      make ${MAKEOPTS} STATIC_LINK=1
+      instDir = "armory_version_raspbian-armhf"
+      mkdir $instDir
+      make install DESTDIR=$instDir
+      cd $instDir
+      tar -zcf ${OUTDIR}/${instDir}.tar.gz usr
+    done


### PR DESCRIPTION
This descriptor is currently untested. It is mainly just a way to
document the build process I used to build for Raspi without Gitian. If
this descriptor happens to work in its current state, it is entirely
coincidental.

This can be merged now and I can always come back to it in the future and make a new pull request.