### PR TITLE
Gitian: Add signassert.py for signing Gitian assert files

### DIFF
--- a/armoryengine/ArmoryUtils.py
+++ b/armoryengine/ArmoryUtils.py
@@ -131,6 +131,9 @@ parser.add_option("--verbosity", dest="verbosity", default=None, type="int", hel
 parser.add_option("--coverage_output_dir", dest="coverageOutputDir", default=None, type="str", help="Unit Test Argument - Do not consume")
 parser.add_option("--coverage_include", dest="coverageInclude", default=None, type="str", help="Unit Test Argument - Do not consume")
 
+# signassert.py arguments
+parser.add_option("-u", "--signer", dest="signer", type="str", help="Wallet code and address in form code/address")
+
 # Some useful constants to be used throughout everything
 BASE58CHARS  = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
 BASE16CHARS  = '0123456789abcdefABCDEF'

--- a/armoryengine/ArmoryUtils.py
+++ b/armoryengine/ArmoryUtils.py
@@ -132,7 +132,7 @@ parser.add_option("--coverage_output_dir", dest="coverageOutputDir", default=Non
 parser.add_option("--coverage_include", dest="coverageInclude", default=None, type="str", help="Unit Test Argument - Do not consume")
 
 # signassert.py arguments
-parser.add_option("-u", "--signer", dest="signer", type="str", help="Wallet code and address in form code/address")
+parser.add_option("-u", "--signer", dest="signer", type="str", help="Wallet ID and address in form ID/address")
 
 # Some useful constants to be used throughout everything
 BASE58CHARS  = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'

--- a/release_scripts/signassert.py
+++ b/release_scripts/signassert.py
@@ -1,0 +1,63 @@
+################################################################################
+#                                                                              #
+# Copyright (C) 2011-2015, Armory Technologies, Inc.                           #
+# Distributed under the GNU Affero General Public License (AGPL v3)            #
+# See LICENSE or http://www.gnu.org/licenses/agpl.html                         #
+#                                                                              #
+################################################################################
+
+import getpass
+import os
+import sys
+sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
+
+from armoryengine.ALL import *
+from jasvet import ASv1CS, readSigBlock, verifySignature
+
+def signAssertFile(wltPath, assertFile):
+   wlt = PyBtcWallet().readWalletFile(wltPath)
+   if not wlt.hasAddr(signAddress):
+      print 'Supplied wallet does not have the correct signing key'
+      exit(1)
+
+   print 'Must unlock wallet to sign the assert file...'
+   while True:
+      passwd = SecureBinaryData(getpass.getpass('Wallet passphrase: '))
+      if not wlt.verifyPassphrase(passwd):
+         print 'Invalid passphrase!'
+         continue
+      break
+
+   wlt.unlock(securePassphrase=passwd)
+   passwd.destroy()
+
+   addrObj = wlt.getAddrByHash160(addrStr_to_hash160(signAddress)[1])
+
+   def doSignFile(inFile, outFile):
+      with open(inFile, 'rb') as f:
+         sigBlock = ASv1CS(addrObj.binPrivKey32_Plain.toBinStr(), f.read())
+
+      with open(outFile, 'wb') as f:
+         f.write(sigBlock)
+
+   doSignFile(assertFile, '%s.sig' % assertFile)
+
+if __name__=='__main__':
+   assertFile = sys.argv[1]
+   wltCode = raw_input('Enter your Armory wallet code (e.g. CeL6h2HD): ')
+   signAddress = raw_input('Enter an address in the wallet with which to sign: ')
+   wltPath = os.path.join(os.path.expanduser('~'), '.armory',
+           'armory_%s_.wallet' % wltCode)
+   if not os.path.exists(wltPath):
+      print 'Wallet file was not found (%s)' % wltPath
+      exit(1)
+   signAssertFile(wltPath, assertFile)
+
+   print ''
+   print 'Verifying file'
+   with open('%s.sig' % assertFile) as f:
+      sig,msg = readSigBlock(f.read())
+      addrB58 = verifySignature(sig, msg, 'v1', ord(ADDRBYTE))
+      print 'Sign addr for:', '%s.sig' % assertFile, addrB58
+
+   print 'Done!'

--- a/release_scripts/signassert.py
+++ b/release_scripts/signassert.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 ################################################################################
 #                                                                              #
 # Copyright (C) 2011-2015, Armory Technologies, Inc.                           #
@@ -43,9 +45,15 @@ def signAssertFile(wltPath, assertFile):
    doSignFile(assertFile, '%s.sig' % assertFile)
 
 if __name__=='__main__':
-   assertFile = sys.argv[1]
-   wltCode = raw_input('Enter your Armory wallet code (e.g. CeL6h2HD): ')
-   signAddress = raw_input('Enter an address in the wallet with which to sign: ')
+   parser = argparse.ArgumentParser(description='sign using ECDSA')
+   parser.add_argument('-u' dest='signer', type=str,
+           help='wallet code and address in form code/address')
+   parser.add_argument('assert_path', type=str,
+           help='path to assert file to be signed')
+   args = parser.parse_args()
+   assertFile = args['assert_path']
+   wltCode = args['signer'].split('/')[0]
+   signAddress = args['signer'].split('/')[1]
    wltPath = os.path.join(os.path.expanduser('~'), '.armory',
            'armory_%s_.wallet' % wltCode)
    if not os.path.exists(wltPath):

--- a/release_scripts/signassert.py
+++ b/release_scripts/signassert.py
@@ -13,7 +13,8 @@ import os
 import sys
 sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
 
-from armoryengine.ALL import *
+from armoryengine.PyBtcWallet import *
+from armoryengine.ArmoryUtils import CLI_OPTIONS, CLI_ARGS
 from jasvet import ASv1CS, readSigBlock, verifySignature
 
 def signAssertFile(wltPath, assertFile):
@@ -45,15 +46,12 @@ def signAssertFile(wltPath, assertFile):
    doSignFile(assertFile, '%s.sig' % assertFile)
 
 if __name__=='__main__':
-   parser = argparse.ArgumentParser(description='sign using ECDSA')
-   parser.add_argument('-u' dest='signer', type=str,
-           help='wallet code and address in form code/address')
-   parser.add_argument('assert_path', type=str,
-           help='path to assert file to be signed')
-   args = parser.parse_args()
-   assertFile = args['assert_path']
-   wltCode = args['signer'].split('/')[0]
-   signAddress = args['signer'].split('/')[1]
+   if not CLI_ARGS:
+      print 'Must supply assert path'
+      exit(1)
+   assertFile = CLI_ARGS[0]
+   wltCode = CLI_OPTIONS.signer.split('/')[0]
+   signAddress = CLI_OPTIONS.signer.split('/')[1]
    wltPath = os.path.join(os.path.expanduser('~'), '.armory',
            'armory_%s_.wallet' % wltCode)
    if not os.path.exists(wltPath):

--- a/release_scripts/signassert.py
+++ b/release_scripts/signassert.py
@@ -23,21 +23,22 @@ def signAssertFile(wltPath, assertFile):
       print 'Supplied wallet does not have the correct signing key'
       exit(1)
 
-   print 'Must unlock wallet to sign the assert file...'
-   passcnt = 0
-   while True:
-      passwd = SecureBinaryData(getpass.getpass('Wallet passphrase: '))
-      if not wlt.verifyPassphrase(passwd):
-         print 'Invalid passphrase!'
-         if passcnt == 2:
-            print 'Too many password attempts. Exiting.'
-            exit(1)
-         passcnt += 1
-         continue
-      break
+   if wlt.useEncryption and wlt.isLocked:
+      print 'Must unlock wallet to sign the assert file...'
+      passcnt = 0
+      while True:
+         passwd = SecureBinaryData(getpass.getpass('Wallet passphrase: '))
+         if not wlt.verifyPassphrase(passwd):
+            print 'Invalid passphrase!'
+            if passcnt == 2:
+               print 'Too many password attempts. Exiting.'
+               exit(1)
+            passcnt += 1
+            continue
+         break
 
-   wlt.unlock(securePassphrase=passwd)
-   passwd.destroy()
+      wlt.unlock(securePassphrase=passwd)
+      passwd.destroy()
 
    addrObj = wlt.getAddrByHash160(addrStr_to_hash160(signAddress)[1])
 

--- a/release_scripts/signassert.py
+++ b/release_scripts/signassert.py
@@ -14,7 +14,7 @@ import sys
 sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
 
 from armoryengine.PyBtcWallet import *
-from armoryengine.ArmoryUtils import CLI_OPTIONS, CLI_ARGS
+from armoryengine.ArmoryUtils import ARMORY_HOME_DIR, CLI_OPTIONS, CLI_ARGS
 from jasvet import ASv1CS, readSigBlock, verifySignature
 
 def signAssertFile(wltPath, assertFile):
@@ -63,8 +63,7 @@ if __name__=='__main__':
    assertFile = CLI_ARGS[0]
    wltCode = CLI_OPTIONS.signer.split('/')[0]
    signAddress = CLI_OPTIONS.signer.split('/')[1]
-   wltPath = os.path.join(os.path.expanduser('~'), '.armory',
-           'armory_%s_.wallet' % wltCode)
+   wltPath = os.path.join(ARMORY_HOME_DIR, 'armory_%s_.wallet' % wltCode)
    if not os.path.exists(wltPath):
       print 'Wallet file was not found (%s)' % wltPath
       exit(1)


### PR DESCRIPTION
@droark 

For use in conjunction with gsign from gitian-builder. The associated gitian-builder PR is devrandom/gitian-builder#93.

This is heavily based on signannounce.py.

While doing this, I realized that there needs to be some way to find all the previously built versions of Armory and include their hashes in the file to be signed. That is the way the announce file currently works. This script currently just signs a single assert file for a single version of Armory for a single OS. I'm not sure the best way to handle making a file that is more like the current announce file. I'm not sure that adding functionality to gitian-builder to combine assert files into some announce file format makes sense, since it seems like the exact format would be Armory-specific. I think it might be best to have a script in release_scripts that Armory uses to take a bunch of assert files, verify the signatures on all of them, and then extract the relevant data and put it into the format that the announce file currently uses. Then that final announce file would be signed.

You would then make all the signed announce files from some group of employees available somewhere for the Secure Downloader to download and verify.

The alternative is to make a signed master list of assert files. That way there is no need to combine assert files into an announce file format. Either way would involve downloading multiple files, but this way probably involves more change to the Secure Downloader than the other way.