### PR TITLE
Release: Verify Gitian/Debian signatures before proceeding with signing

### DIFF
--- a/release_scripts/Step1_Online_PrepareForSigning.py
+++ b/release_scripts/Step1_Online_PrepareForSigning.py
@@ -20,7 +20,7 @@ from release_settings import getReleaseParams, getMasterPackageList
 masterPkgList = getMasterPackageList()
 
 MAIN_CLONE_URL = 'https://github.com/etotheipi/BitcoinArmory.git'
-SIGS_CLONE_URL = 'https://github.com/armorytechetotheipi/armory-reproducible-test.git'
+SIGS_CLONE_URL = 'https://github.com/armorytech/armory-reproducible-test.git'
 
 if len(argv)<3:
    import textwrap

--- a/release_scripts/Step1_Online_PrepareForSigning.py
+++ b/release_scripts/Step1_Online_PrepareForSigning.py
@@ -20,7 +20,7 @@ from release_settings import getReleaseParams, getMasterPackageList
 masterPkgList = getMasterPackageList()
 
 MAIN_CLONE_URL = 'https://github.com/etotheipi/BitcoinArmory.git'
-SIGS_CLONE_URL = 'https://github.com/etotheipi/armoryreproduciblesigs.git'
+SIGS_CLONE_URL = 'https://github.com/armorytechetotheipi/armory-reproducible-test.git'
 
 if len(argv)<3:
    import textwrap
@@ -45,7 +45,7 @@ shaCore = argv[5] if len(argv)>5 else None
 
 instDst      = os.path.join(outDir, 'installers')
 mainCloneDir = os.path.join(outDir, 'BitcoinArmory')
-sigsCloneDir = os.path.join(outDir, 'armoryreproduciblesigs')
+sigsCloneDir = os.path.join(outDir, 'armory-reproducible-test')
 rscrDir      = os.path.join(outDir, 'release_scripts')
 annDst       = os.path.join(outDir, 'unsignedannounce')
 

--- a/release_scripts/Step1_Online_PrepareForSigning.py
+++ b/release_scripts/Step1_Online_PrepareForSigning.py
@@ -19,7 +19,8 @@ from release_settings import getReleaseParams, getMasterPackageList
 
 masterPkgList = getMasterPackageList()
 
-CLONE_URL = 'https://github.com/etotheipi/BitcoinArmory.git'
+MAIN_CLONE_URL = 'https://github.com/etotheipi/BitcoinArmory.git'
+SIGS_CLONE_URL = 'https://github.com/etotheipi/armoryreproduciblesigs.git'
 
 if len(argv)<3:
    import textwrap
@@ -42,10 +43,11 @@ outDir  = argv[3] if len(argv)>3 else './exportToOffline'
 annSrc  = argv[4] if len(argv)>4 else './unsignedannounce'
 shaCore = argv[5] if len(argv)>5 else None
 
-instDst  = os.path.join(outDir, 'installers')
-cloneDir = os.path.join(outDir, 'BitcoinArmory')
-rscrDir  = os.path.join(outDir, 'release_scripts')
-annDst   = os.path.join(outDir, 'unsignedannounce')
+instDst      = os.path.join(outDir, 'installers')
+mainCloneDir = os.path.join(outDir, 'BitcoinArmory')
+sigsCloneDir = os.path.join(outDir, 'armoryreproduciblesigs')
+rscrDir      = os.path.join(outDir, 'release_scripts')
+annDst       = os.path.join(outDir, 'unsignedannounce')
 
 if os.path.exists(outDir):
    shutil.rmtree(outDir)
@@ -78,7 +80,8 @@ for pkgName,pkgInfo in masterPkgList.iteritems():
       execAndWait(['scp', '-P', str(port), hostPath, copyTo])
 
 
-execAndWait(['git', 'clone', CLONE_URL, cloneDir])
+execAndWait(['git', 'clone', MAIN_CLONE_URL, mainCloneDir])
+execAndWait(['git', 'clone', SIGS_CLONE_URL, sigsCloneDir])
 shutil.copytree('../release_scripts', rscrDir)
 shutil.copytree(annSrc, annDst)
 

--- a/release_scripts/Step2_Offline_PackageSigning.py
+++ b/release_scripts/Step2_Offline_PackageSigning.py
@@ -234,6 +234,7 @@ import urllib2
 import json
 import yaml # for assert file
 import deb822 # for buildinfo file
+from hashlib import sha256
 
 # require valid signatures from threshold number out of total signers
 signers = ['ID/address', 'ID/address', 'ID/address', 'ID/address',
@@ -327,8 +328,22 @@ for pkgName, pkgInfo in masterPkgList.iteritems():
       exit(1)
 
    print ''
-   print ('Signature threshold was met (%s of %s). Signing process will now'
-          ' continue.') % (threshold, len(signers))
+   f = open(getSrcPath(pkgName), 'rb')
+   with f:
+      fileHash = '%s' % sha256(f.read()).hexdigest()
+   if fileHash == hashDict[oldSigner][0]:
+      print ('File hash matches the hash of the file that was built by'
+             ' the signers.')
+   else:
+      print ('File hash does not match the hash of the file that was built by'
+             ' the signers. Please ensure the hashes match before trying again.')
+      exit(1)
+
+   print ''
+   print ('Signature threshold was met (%s of %s) and the hash of the file to'
+          ' be signed matches the hashes obtained during the Gitian or Debian'
+          ' build process. Signing process will now continue.') % (
+                  threshold, len(signers))
 
 
 

--- a/release_scripts/Step2_Offline_PackageSigning.py
+++ b/release_scripts/Step2_Offline_PackageSigning.py
@@ -299,14 +299,13 @@ for pkgName, pkgInfo in masterPkgList.iteritems():
 
          # Continue with code common to both assert and buildinfo files
          try:
-            for idx in range(len(hashDict[signer])):
-               if hashDict[signer][idx] == hashDict[oldSigner][idx]:
-                  print 'Hash match for signers %s and %s' % (signer, oldSigner)
-                  oldSigner = signer
-                  sigCnt += weights[i]
-               else:
-                  print ('Hash mismatch for signers %s and %s. Signature does'
-                         ' not count as valid.') % (signer, oldSigner)
+            if hashDict[signer][0] == hashDict[oldSigner][0]:
+               print 'Hash match for signers %s and %s' % (signer, oldSigner)
+               oldSigner = signer
+               sigCnt += weights[i]
+            else:
+               print ('Hash mismatch for signers %s and %s. Signature does'
+                      ' not count as valid.') % (signer, oldSigner)
          except:
             # First time, so no oldSigner yet.
             print ('Did not compare hash for signer %s, because this is the'

--- a/release_scripts/reproducible.README
+++ b/release_scripts/reproducible.README
@@ -1,0 +1,24 @@
+This README contains information about the use of reproducible builds in the
+Armory release process.
+
+The reproducible build integration into the release process caused the step 2
+release script to require a couple of extra Python modules. PyYAML is required
+to parse the YAML in the assert files that are output by Gitian. PyYAML allows
+us to import yaml. The python-debian package is required to parse the buildinfo
+file that is output by the Debian Reproducible Build process. That package
+allows us to import deb822. Some relevant links are below:
+
+https://packages.debian.org/jessie/python-debian
+https://pypi.python.org/pypi/python-debian
+http://packages.ubuntu.com/trusty/python-debian
+https://packages.debian.org/jessie/python-yaml
+https://pypi.python.org/pypi/PyYAML
+http://packages.ubuntu.com/trusty/python-yaml
+
+The repo that contains the gathered signatures is located at the following URL:
+
+https://github.com/armorytech/armory-reproducible
+
+The test version of that repo is:
+
+https://github.com/armorytech/armory-reproducible-test


### PR DESCRIPTION
@droark 

As the commit message says, this needs actual ID/address pairs to be hardcoded before use. You can see from the commented out ID/address pairs that I tested this by requiring 2 of 3 valid signatures.

This requires a GitianName and GitianExt to be added to pkgInfo (pkgInfo is derived from release_settings.py). In the case of my RasPi test, I used "raspi" as GitianName (it is derived from the Gitian descriptor) and .assert as GitianExt (it is .assert for everything except the Deb packages, which uses .buildinfo).

The part where the buildinfo file is parsed for that hash is untested, because I only tested this with RasPi so far. But I wanted to get this code up here, so it could start being reviewed sooner, rather than later.

I ran into issues finishing the execution of the step 2 script (was missing some dllink_temp file), but since I didn't modify anything past a certain point (and I was able to test up to that point), the rest should work as normal if you have the correct setup like Alan does.