### PR TITLE
Restrict IPC port to local connections

### DIFF
--- a/ArmoryQt.py
+++ b/ArmoryQt.py
@@ -2307,7 +2307,7 @@ class ArmoryMainWindow(QMainWindow):
          try:
             self.InstanceListener = ArmoryListenerFactory(self.bringArmoryToFront, \
                                                           uriClick_partial )
-            reactor.listenTCP(CLI_OPTIONS.interport, self.InstanceListener)
+            reactor.listenTCP(CLI_OPTIONS.interport, self.InstanceListener, 1, '127.0.0.1')
          except twisted.internet.error.CannotListenError:
             LOGWARN('Socket already occupied!  This must be a duplicate Armory')
             QMessageBox.warning(self, tr('Already Open'), tr("""


### PR DESCRIPTION
Currently, Armory listens for interprocess connections on port 8223 on all interfaces. This is potentially dangerous, as this means that an attacker can trigger a payment dialog on the users screen from the network (or potentially the internet if the machine is not firewalled).

Example (where 192.168.1.6 is the remote IP of the computer running Armory):

```
echo 'bitcoin:1ArmoryXcfq7TnCSuZa9fQjRYwJ4bkRKfv?amount=100' | nc 192.168.1.6 8223
```

This can be fixed by making armory listen only on the local interface with my commit.
